### PR TITLE
bug 1189118 - Update package.json to node v 0.10.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "./node_modules/.bin/nodeunit tests"
   },
   "engines": {
-    "node": "0.10.26"
+    "node": "0.10.36"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
First step toward upgrade.  To test:

1.  Install nvm and use node v 0.10.36
2.  npm install
3.  `./node_modules/.bin/nodeunit tests`