### PR TITLE
bug 1218563: Load config from environment

### DIFF
--- a/lib/kumascript/conf.js
+++ b/lib/kumascript/conf.js
@@ -48,6 +48,12 @@ var DEFAULT_CONFIG = {
 
 // ### Initialize configuration
 //
+// Load from environment
+// Use '__' as separator
+// server__port=9080
+nconf.env('__');
+
+//
 // Attempt to load from a prioritized series of configuration files.
 //
 // 1. Environ var `KUMASCRIPT_CONFIG`


### PR DESCRIPTION
Use double-underscore as object marker, like ``log__console=true``.

A quick test (assuming you have your node environment all set up):

```
$ export repl__port=9071
$ node run.js
$ telnet localhost 9071
ks> .help
ks> .exit
```

r? @groovecoder @jgmize 