### PR TITLE
Bug 1321963 - Check slug before accessing property in AddonSidebar.ejs

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -6,7 +6,7 @@ var baseURL = "/" + locale + "/docs/Mozilla/Add-ons/";
 
 function currentPageIsUnder(root) {
   rootSlug = "Mozilla/Add-ons/" + root;
-  if (slug.indexOf(rootSlug) != -1) {
+  if (slug && slug.indexOf(rootSlug) != -1) {
     return "open";
   }
   return "closed";


### PR DESCRIPTION
slug is undefined in preview page, so we should check if slug is there before accessing property.
this fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1321963