### PR TITLE
Update spec names in prep for documenting Chrome 55/Opera 42.

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -48,7 +48,7 @@ var specList = {
         url  : "https://w3c.github.io/ambient-light/"
     },
     'Async Function':{
-        name : "ECMAScript Async Function",
+        name : "ECMAScript Async Functions",
         url  : "https://tc39.github.io/ecmascript-asyncawait/"
     },
     'Background Sync': {

--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -256,7 +256,7 @@ var specList = {
         url  : 'https://drafts.csswg.org/css-syntax/'
     },
     'CSS3 Text':{
-        name : 'CSS Text Level&nbsp;3',
+        name : 'CSS Text Module Level&nbsp;3',
         url  : "https://drafts.csswg.org/css-text-3/"
     },
     'CSS3 Text Decoration':{

--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -348,7 +348,7 @@ var specList = {
         url  : "https://drafts.csswg.org/css-grid/"
     },
     'CSS Masks':{
-        name : 'CSS Masking Module Level 1',
+        name : 'CSS Masking Module Level&nbsp;1',
         url  : 'https://drafts.fxtf.org/css-masking-1/'
     },
     'CSS Non-element Selectors':{

--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -348,7 +348,7 @@ var specList = {
         url  : "https://drafts.csswg.org/css-grid/"
     },
     'CSS Masks':{
-        name : 'CSS Masking Level&nbsp;1',
+        name : 'CSS Masking Module Level 1',
         url  : 'https://drafts.fxtf.org/css-masking-1/'
     },
     'CSS Non-element Selectors':{


### PR DESCRIPTION
Update spec names in prep for documenting [Chrome 55/Opera 42](https://www.chromestatus.com/features#milestone%3D55).