### PR TITLE
Bug 1325352 - Do nothing in WebExtCompat macro in preview mode.

### DIFF
--- a/macros/WebExtCompat.ejs
+++ b/macros/WebExtCompat.ejs
@@ -10,6 +10,9 @@ var none = "None."
 
 // API is either $0 or the name of the calling page
 var slug = env.slug;
+if (!slug) {
+    return;
+}
 var pathComponents = slug.split("/");
 if (pathComponents < 1) {
     return;


### PR DESCRIPTION
slug is undefined in preview mode, so added the check in WebExtCompat macro to bailout.
