### PR TITLE
ARIARole macro: Use <code> & link to editor draft

### DIFF
--- a/macros/ARIARole.ejs
+++ b/macros/ARIARole.ejs
@@ -4,6 +4,6 @@
 //
 //  $0 - role
 
-var link = 'http://www.w3.org/TR/wai-aria/roles#' + $0;
+var link = 'https://w3c.github.io/aria/aria/aria.html#' + $0;
 %>
-<a href="<%=link%>" class="external"><%=$0%></a>
+<code><a href="<%=link%>" class="external"><%=$0%></a></code>


### PR DESCRIPTION
* Just like element names and attribute names, ARIA role names should be
  rendered in monospace, so we should use `<code>` in the macro

* The document at https://www.w3.org/TR/wai-aria/ is a two-year-old obsolete
  version of the ARIA spec that has been superseded. It is better practice to
  instead link to the continuosly-maintained version of the ARIA spec that’s at
  https://w3c.github.io/aria/aria/aria.html, which also includes newer ARIA 1.1
  that are now referenced in the HTML spec.