### PR TITLE
obsoleteGeneric: complete spanish translation

### DIFF
--- a/macros/obsoleteGeneric.ejs
+++ b/macros/obsoleteGeneric.ejs
@@ -108,6 +108,7 @@ var str_desc = mdn.localString({
   "en-US": "This feature is obsolete. Although it may still work in some browsers, its use is discouraged since it could be removed at any time. Try to avoid using it.",
   "de":    "Dieses Feature ist veraltet. Obwohl es in manchen Browsern immer noch funktioniert, wird von seiner Benutzung abgeraten, da es jederzeit entfernt werden kann. Es sollte daher nicht mehr verwendet werden.",
   "fr":    "Cette fonctionnalité est obsolète. Bien qu'encore supportée par des navigateurs, son utilisation est découragée pour tout nouveau projet. Évitez de l'utiliser.",
+  "es":    "Esta funcionalidad es obsoleta. Aunque puede aún funcionar en algunos navegadores, se desalienta su uso ya que puede ser removida en cualquier momento. Evite usarla.",
   "ja":    "この機能は廃止されました。まだいくつかのブラウザーで動作するかもしれませんが、いつ削除されてもおかしくないので、使わないようにしましょう。",
   "ru":    "Эта возможность вышла из употребления. Хотя она может продолжать работать в некоторых браузерах, её использование не рекомендуется, поскольку она может быть удалена в любое время. Старайтесь избегать её использования."
 });


### PR DESCRIPTION
As you can see in this [entry](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/observe) the obsolete header is only partially translated to spanish. This PR addresses that issue.