### PR TITLE
Migrate API groups & interfaces to mdn/data json files

### DIFF
--- a/macros/APIFeatureList.ejs
+++ b/macros/APIFeatureList.ejs
@@ -1,8 +1,8 @@
 <%
 // Variables and data
 
-// $0 is the API whose properties/methods you want listed on the page, as listed in the GroupData macro
-// see https://developer.mozilla.org/en-US/docs/Template:GroupData
+// $0 is the API whose properties/methods you want listed on the page, as listed in the group data
+// see https://github.com/mdn/data/blob/master/api/groups.json
 
 var slug = $0;
 
@@ -10,10 +10,10 @@ var locale = env.locale;
 var finalSlugList = [];
 var output = '';
 
-var webAPIGroups = string.deserialize(template('GroupData'));
-var webAPIInterfaces = webAPIGroups[0][slug]['interfaces'];
-var webAPIMethods = webAPIGroups[0][slug]['methods'];
-var webAPIProperties = webAPIGroups[0][slug]['properties'];
+var webAPIGroups = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/groups.json");
+var webAPIInterfaces = webAPIGroups[slug]['interfaces'];
+var webAPIMethods = webAPIGroups[slug]['methods'];
+var webAPIProperties = webAPIGroups[slug]['properties'];
 
 // Populating the output
 
@@ -30,7 +30,7 @@ for(i = 0; i < webAPIInterfaces.length ; i++) {
     for(j = 0; j < childPages.length ; j++) {
       var fixedTitle = childPages[j].title.replace('.','/');
       finalSlugList.push('/' + locale + '/docs/Web/API/' + fixedTitle);
-    } 
+    }
   }
 }
 
@@ -50,21 +50,21 @@ output += '<h2 id="Methods_and_properties_list">Methods and properties list</h2>
 
 finalSlugList.sort();
 
-for(l = 0 ; l < finalSlugList.length ; l++) {   
+for(l = 0 ; l < finalSlugList.length ; l++) {
   var currentSlug = finalSlugList[l];
   var linkText;
-  
+
   var slugSplit = currentSlug.split('/');
   if(slugSplit[slugSplit.length-2]) {
     linkText = slugSplit[slugSplit.length-2] + '.' + slugSplit[slugSplit.length-1];
   } else {
-    linkText = slugSplit[slugSplit.length-1];      
-  }   
-  
+    linkText = slugSplit[slugSplit.length-1];
+  }
+
   if(finalSlugList[l].indexOf('()') !== -1) {
     currentSlug = finalSlugList[l].replace('()','');
   }
-  
+
   output += '<li><code><a href="' + currentSlug + '">' + linkText + '</a></code></li>';
 }
 

--- a/macros/APIRef.ejs
+++ b/macros/APIRef.ejs
@@ -20,9 +20,10 @@ var escapeQuotes = mdn.escapeQuotes;
 var htmlEscape = kuma.htmlEscape;
 var rtlLocales = ['ar', 'he', 'fa'];
 
-var webAPIData = string.deserialize(template("InterfaceData"));
+var webAPIData = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/interfaces.json");
+
 if (group) {
-  var webAPIGroups = string.deserialize(template("GroupData"));
+  var webAPIGroups = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/groups.json");
 }
 
 var commonl10n = string.deserialize(template('L10n:Common'));
@@ -42,20 +43,20 @@ var text = {
 
 // Collect all the things
 var mainIFPages = page.subpagesExpand('/en-US/docs/Web/API/' + mainIF);
-var impl = webAPIData[0][mainIF] != undefined ? webAPIData[0][mainIF].impl : [];
-var inh = webAPIData[0][mainIF] != undefined ? webAPIData[0][mainIF].inh : '';
+var impl = webAPIData[mainIF] != undefined ? webAPIData[mainIF].impl : [];
+var inh = webAPIData[mainIF] != undefined ? webAPIData[mainIF].inh : '';
 var related = [];
 var events = []
-if (group && webAPIGroups[0][group]) {
-  var rel_if = webAPIGroups[0][group].interfaces || [];
-  var rel_met = webAPIGroups[0][group].methods || [];
-  var rel_prop = webAPIGroups[0][group].properties || [];
+if (group && webAPIGroups[group]) {
+  var rel_if = webAPIGroups[group].interfaces || [];
+  var rel_met = webAPIGroups[group].methods || [];
+  var rel_prop = webAPIGroups[group].properties || [];
   related = rel_if.concat(rel_met, rel_prop);
   related.splice(related.indexOf(mainIF), 1);
   related.sort();
-  events = webAPIGroups[0][group].events || [];
+  events = webAPIGroups[group].events || [];
 }
-    
+
 var pageList = mainIFPages;
 
 var properties = [];
@@ -103,8 +104,8 @@ ctors.sort(APISort);
 function getInheritance(inh) {
   if (inh.length > 0) {
     inheritedIF.push(inh);
-    if (webAPIData[0].hasOwnProperty(inh)) {
-        var inh = webAPIData[0][inh].inh;
+    if (webAPIData.hasOwnProperty(inh)) {
+        var inh = webAPIData[inh].inh;
         getInheritance(inh);
     }
   }
@@ -117,9 +118,9 @@ function getImplementedBy(data) {
       implementedBy.push(key);
     }
   }
-  implementedBy.sort();  
+  implementedBy.sort();
 }
-getImplementedBy(webAPIData[0]);
+getImplementedBy(webAPIData);
 
 // output helpers
 
@@ -139,7 +140,7 @@ function buildSublist(pages, title) {
     var url = aPage.url.replace('en-US', locale);
     var titleSplit = htmlEscape(aPage.title).split('.'); // Two cases, as sometimes the interface name is forgotten in the title:
     var title = titleSplit[titleSplit.length - 1];       // "WebGLRenderingContext.activeTexture()" and "activeTexture()" should both become "activeTexture()"
-    
+
     var translated = false;
     if (locale != 'en-US') {
         aPage.translations.forEach(function(translation){
@@ -152,15 +153,15 @@ function buildSublist(pages, title) {
             }
         });
     }
-    
+
     var cta = '';
      if (!translated && locale != 'en-US') {
         cta += ' <a href="'+ url +'$translate" style="opacity:0.5" title="'+ text['title'] + '">' + text['translate'] + '</a>';
     }
-    
-    
+
+
     result += '<li>';
-    
+
     if (hasTag(aPage, 'Experimental')) {
         result += badges.ExperimentalBadge;
     }
@@ -177,25 +178,25 @@ function buildSublist(pages, title) {
         result += badges.ObsoleteBadge;
         result += '<s class="obsoleteElement">';
     }
-    
+
     if (rtlLocales.indexOf(locale) != -1) {
         result += '<bdi>';
     }
-    
+
     if (slug == aPage.slug) {
         result += '<em><code>' + title + '</code></em>'
     } else {
         result += '<a href="' + url + '" title="' + summary + '"><code>' + title + '</code></a>' + cta;
     }
-    
+
     if (rtlLocales.indexOf(locale) != -1) {
         result += '</bdi>';
     }
-    
+
     if (hasTag(aPage, 'Obsolete')) {
         result += '</s>';
     }
-    
+
     result += '</li>';
   }
 
@@ -232,19 +233,19 @@ function buildEventList(events, title) {
 
 // output
 output = '<section class="Quick_links" id="Quick_Links"><ol>';
-if (group && webAPIGroups[0][group] && webAPIGroups[0][group].overview) {
-  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[0][group].overview[0] + '</a></strong></li>';
+if (group && webAPIGroups[group] && webAPIGroups[group].overview) {
+  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[group].overview[0] + '</a></strong></li>';
 }
 output += '<li><strong><a href="' +  APIHref + '/' + mainIF + '"><code>' + mainIF + '</a></code></strong></li>';
 
-if (ctors.length > 0) { 
+if (ctors.length > 0) {
   output += buildSublist(ctors, text['Constructor']);
 }
 
-if (properties.length > 0) { 
+if (properties.length > 0) {
   output += buildSublist(properties, text['Properties']);
 }
-if (methods.length > 0) { 
+if (methods.length > 0) {
   output += buildSublist(methods, text['Methods']);
 }
 if (inh.length > 0) {

--- a/macros/DefaultAPISidebar.ejs
+++ b/macros/DefaultAPISidebar.ejs
@@ -16,7 +16,7 @@ var escapeQuotes = mdn.escapeQuotes;
 // slug is not available in preview mode.
 if (slug && group) {
 
-var webAPIGroups = string.deserialize(template("GroupData"));
+var webAPIGroups = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/groups.json");
 
 var commonl10n = string.deserialize(template('L10n:Common'));
 
@@ -30,17 +30,17 @@ var text = {
     'title': mdn.getLocalString(commonl10n, 'TranslationCTA'),
 };
 
-if (webAPIGroups[0][group]) {
+if (webAPIGroups[group]) {
 
-var interfaces = webAPIGroups[0][group].interfaces || [];
-var methods = webAPIGroups[0][group].methods || [];
-var properties = webAPIGroups[0][group].properties || [];
-var events = webAPIGroups[0][group].events || [];
+var interfaces = webAPIGroups[group].interfaces || [];
+var methods = webAPIGroups[group].methods || [];
+var properties = webAPIGroups[group].properties || [];
+var events = webAPIGroups[group].events || [];
 var guides = [];
 
-if (webAPIGroups[0][group].overview) {
-    guides = page.subpagesExpand('/en-US/docs/Web/API/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_'));
-    var otherGuides = webAPIGroups[0][group].guides || [];
+if (webAPIGroups[group].overview) {
+    guides = page.subpagesExpand('/en-US/docs/Web/API/' + webAPIGroups[group].overview[0].replace(/ /g, '_'));
+    var otherGuides = webAPIGroups[group].guides || [];
     guides = guides.concat(otherGuides);
 }
 
@@ -52,7 +52,7 @@ function buildSublist(pages, title) {
     var summary = escapeQuotes(aPage.summary || '');
     var url = aPage.url.replace('en-US', locale);
     var title = htmlEscape(aPage.title);
-    
+
     var translated = false;
     if (locale != 'en-US' && aPage.translations) {
         aPage.translations.forEach(function(translation){
@@ -64,12 +64,12 @@ function buildSublist(pages, title) {
             }
         });
     }
-    
+
     var cta = '';
      if (!translated && locale != 'en-US' && aPage.translations) {
         cta += ' <a href="'+ url +'$translate" style="opacity:0.5" title="'+ text['title'] + '">' + text['translate'] + '</a>';
     }
-    
+
     result += '<li>';
     result += '<a href="' + url + '" title="' + summary + '">' + title + '</a>' + cta;
     result += '</li>';
@@ -109,8 +109,8 @@ function buildEventList(events, title) {
 // output
 output = '<section class="Quick_links" id="Quick_Links"><ol>';
 
-if (webAPIGroups[0][group].overview) {
-  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[0][group].overview[0] + '</a></strong></li>';
+if (webAPIGroups[group].overview) {
+  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[group].overview[0] + '</a></strong></li>';
 }
 
 if (guides.length > 0) {

--- a/macros/FirefoxOSAPIRef.ejs
+++ b/macros/FirefoxOSAPIRef.ejs
@@ -21,9 +21,10 @@ var escapeQuotes = mdn.escapeQuotes;
 var htmlEscape = kuma.htmlEscape;
 var rtlLocales = ['ar', 'he', 'fa'];
 
-var webAPIData = string.deserialize(template("InterfaceData"));
+var webAPIData = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/interfaces.json");
+
 if (group) {
-  var webAPIGroups = string.deserialize(template("GroupData"));
+  var webAPIGroups = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/groups.json");
 }
 
 var commonl10n = string.deserialize(template('L10n:Common'));
@@ -43,20 +44,20 @@ var text = {
 
 // Collect all the things
 var mainIFPages = page.subpagesExpand('/en-US/docs/Mozilla/Firefox_OS/API/' + mainIF);
-var impl = webAPIData[0][mainIF] != undefined ? webAPIData[0][mainIF].impl : [];
-var inh = webAPIData[0][mainIF] != undefined ? webAPIData[0][mainIF].inh : '';
+var impl = webAPIData[mainIF] != undefined ? webAPIData[mainIF].impl : [];
+var inh = webAPIData[mainIF] != undefined ? webAPIData[mainIF].inh : '';
 var related = [];
 var events = []
-if (group && webAPIGroups[0][group]) {
-  var rel_if = webAPIGroups[0][group].interfaces || [];
-  var rel_met = webAPIGroups[0][group].methods || [];
-  var rel_prop = webAPIGroups[0][group].properties || [];
+if (group && webAPIGroups[group]) {
+  var rel_if = webAPIGroups[group].interfaces || [];
+  var rel_met = webAPIGroups[group].methods || [];
+  var rel_prop = webAPIGroups[group].properties || [];
   related = rel_if.concat(rel_met, rel_prop);
   related.splice(related.indexOf(mainIF), 1);
   related.sort();
-  events = webAPIGroups[0][group].events || [];
+  events = webAPIGroups[group].events || [];
 }
-    
+
 var pageList = mainIFPages;
 
 var properties = [];
@@ -104,8 +105,8 @@ ctors.sort(APISort);
 function getInheritance(inh) {
   if (inh.length > 0) {
     inheritedIF.push(inh);
-    if (webAPIData[0].hasOwnProperty(inh)) {
-        var inh = webAPIData[0][inh].inh;
+    if (webAPIData.hasOwnProperty(inh)) {
+        var inh = webAPIData[inh].inh;
         getInheritance(inh);
     }
   }
@@ -118,9 +119,9 @@ function getImplementedBy(data) {
       implementedBy.push(key);
     }
   }
-  implementedBy.sort();  
+  implementedBy.sort();
 }
-getImplementedBy(webAPIData[0]);
+getImplementedBy(webAPIData);
 
 // output helpers
 
@@ -140,7 +141,7 @@ function buildSublist(pages, title) {
     var url = aPage.url.replace('en-US', locale);
     var titleSplit = htmlEscape(aPage.title).split('.'); // Two cases, as sometimes the interface name is forgotten in the title:
     var title = titleSplit[titleSplit.length - 1];       // "WebGLRenderingContext.activeTexture()" and "activeTexture()" should both become "activeTexture()"
-    
+
     var translated = false;
     if (locale != 'en-US') {
         aPage.translations.forEach(function(translation){
@@ -153,15 +154,15 @@ function buildSublist(pages, title) {
             }
         });
     }
-    
+
     var cta = '';
      if (!translated && locale != 'en-US') {
         cta += ' <a href="'+ url +'$translate" style="opacity:0.5" title="'+ text['title'] + '">' + text['translate'] + '</a>';
     }
-    
-    
+
+
     result += '<li>';
-    
+
     if (hasTag(aPage, 'Experimental')) {
         result += badges.ExperimentalBadge;
     }
@@ -178,25 +179,25 @@ function buildSublist(pages, title) {
         result += badges.ObsoleteBadge;
         result += '<s class="obsoleteElement">';
     }
-    
+
     if (rtlLocales.indexOf(locale) != -1) {
         result += '<bdi>';
     }
-    
+
     if (slug == aPage.slug) {
         result += '<em><code>' + title + '</code></em>'
     } else {
         result += '<a href="' + url + '" title="' + summary + '"><code>' + title + '</code></a>' + cta;
     }
-    
+
     if (rtlLocales.indexOf(locale) != -1) {
         result += '</bdi>';
     }
-    
+
     if (hasTag(aPage, 'Obsolete')) {
         result += '</s>';
     }
-    
+
     result += '</li>';
   }
 
@@ -235,19 +236,19 @@ function buildEventList(events, title) {
 
 // output
 output = '<section class="Quick_links" id="Quick_Links"><ol>';
-if (group && webAPIGroups[0][group] && webAPIGroups[0][group].overview) {
-  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[0][group].overview[0] + '</a></strong></li>';
+if (group && webAPIGroups[group] && webAPIGroups[group].overview) {
+  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[group].overview[0] + '</a></strong></li>';
 }
 output += '<li><strong><a href="' +  APIHref + '/' + mainIF + '"><code>' + mainIF + '</a></code></strong></li>';
 
-if (ctors.length > 0) { 
+if (ctors.length > 0) {
   output += buildSublist(ctors, text['Constructor']);
 }
 
-if (properties.length > 0) { 
+if (properties.length > 0) {
   output += buildSublist(properties, text['Properties']);
 }
-if (methods.length > 0) { 
+if (methods.length > 0) {
   output += buildSublist(methods, text['Methods']);
 }
 if (inh.length > 0) {

--- a/macros/FirefoxOSAPISidebar.ejs
+++ b/macros/FirefoxOSAPISidebar.ejs
@@ -17,7 +17,7 @@ var escapeQuotes = mdn.escapeQuotes;
 // slug is not available in preview mode.
 if (slug && group) {
 
-var webAPIGroups = string.deserialize(template("GroupData"));
+var webAPIGroups = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/groups.json");
 
 var commonl10n = string.deserialize(template('L10n:Common'));
 
@@ -31,17 +31,17 @@ var text = {
     'title': mdn.getLocalString(commonl10n, 'TranslationCTA'),
 };
 
-if (webAPIGroups[0][group]) {
+if (webAPIGroups[group]) {
 
-var interfaces = webAPIGroups[0][group].interfaces || [];
-var methods = webAPIGroups[0][group].methods || [];
-var properties = webAPIGroups[0][group].properties || [];
-var events = webAPIGroups[0][group].events || [];
+var interfaces = webAPIGroups[group].interfaces || [];
+var methods = webAPIGroups[group].methods || [];
+var properties = webAPIGroups[group].properties || [];
+var events = webAPIGroups[group].events || [];
 var guides = [];
 
-if (webAPIGroups[0][group].overview) {
-    guides = page.subpagesExpand('/en-US/docs/Mozilla/Firefox_OS/API/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_'));
-    var otherGuides = webAPIGroups[0][group].guides || [];
+if (webAPIGroups[group].overview) {
+    guides = page.subpagesExpand('/en-US/docs/Mozilla/Firefox_OS/API/' + webAPIGroups[group].overview[0].replace(/ /g, '_'));
+    var otherGuides = webAPIGroups[group].guides || [];
     guides = guides.concat(otherGuides);
 }
 
@@ -53,7 +53,7 @@ function buildSublist(pages, title) {
     var summary = escapeQuotes(aPage.summary || '');
     var url = aPage.url.replace('en-US', locale);
     var title = htmlEscape(aPage.title);
-    
+
     var translated = false;
     if (locale != 'en-US' && aPage.translations) {
         aPage.translations.forEach(function(translation){
@@ -65,12 +65,12 @@ function buildSublist(pages, title) {
             }
         });
     }
-    
+
     var cta = '';
      if (!translated && locale != 'en-US' && aPage.translations) {
         cta += ' <a href="'+ url +'$translate" style="opacity:0.5" title="'+ text['title'] + '">' + text['translate'] + '</a>';
     }
-    
+
     result += '<li>';
     result += '<a href="' + url + '" title="' + summary + '">' + title + '</a>' + cta;
     result += '</li>';
@@ -115,8 +115,8 @@ function buildEventList(events, title) {
 // output
 output = '<section class="Quick_links" id="Quick_Links"><ol>';
 
-if (webAPIGroups[0][group].overview) {
-  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[0][group].overview[0] + '</a></strong></li>';
+if (webAPIGroups[group].overview) {
+  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[group].overview[0] + '</a></strong></li>';
 }
 
 if (guides.length > 0) {

--- a/macros/FirefoxOSDefaultAPISidebar.ejs
+++ b/macros/FirefoxOSDefaultAPISidebar.ejs
@@ -17,7 +17,7 @@ var escapeQuotes = mdn.escapeQuotes;
 // slug is not available in preview mode.
 if (slug && group) {
 
-var webAPIGroups = string.deserialize(template("GroupData"));
+var webAPIGroups = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/groups.json");
 
 var commonl10n = string.deserialize(template('L10n:Common'));
 
@@ -31,17 +31,17 @@ var text = {
     'title': mdn.getLocalString(commonl10n, 'TranslationCTA'),
 };
 
-if (webAPIGroups[0][group]) {
+if (webAPIGroups[group]) {
 
-var interfaces = webAPIGroups[0][group].interfaces || [];
-var methods = webAPIGroups[0][group].methods || [];
-var properties = webAPIGroups[0][group].properties || [];
-var events = webAPIGroups[0][group].events || [];
+var interfaces = webAPIGroups[group].interfaces || [];
+var methods = webAPIGroups[group].methods || [];
+var properties = webAPIGroups[group].properties || [];
+var events = webAPIGroups[group].events || [];
 var guides = [];
 
-if (webAPIGroups[0][group].overview) {
-    guides = page.subpagesExpand('/en-US/docs/Mozilla/Firefox_OS/API/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_'));
-    var otherGuides = webAPIGroups[0][group].guides || [];
+if (webAPIGroups[group].overview) {
+    guides = page.subpagesExpand('/en-US/docs/Mozilla/Firefox_OS/API/' + webAPIGroups[group].overview[0].replace(/ /g, '_'));
+    var otherGuides = webAPIGroups[group].guides || [];
     guides = guides.concat(otherGuides);
 }
 
@@ -53,7 +53,7 @@ function buildSublist(pages, title) {
     var summary = escapeQuotes(aPage.summary || '');
     var url = aPage.url.replace('en-US', locale);
     var title = htmlEscape(aPage.title);
-    
+
     var translated = false;
     if (locale != 'en-US' && aPage.translations) {
         aPage.translations.forEach(function(translation){
@@ -65,12 +65,12 @@ function buildSublist(pages, title) {
             }
         });
     }
-    
+
     var cta = '';
      if (!translated && locale != 'en-US' && aPage.translations) {
         cta += ' <a href="'+ url +'$translate" style="opacity:0.5" title="'+ text['title'] + '">' + text['translate'] + '</a>';
     }
-    
+
     result += '<li>';
     result += '<a href="' + url + '" title="' + summary + '">' + title + '</a>' + cta;
     result += '</li>';
@@ -115,8 +115,8 @@ function buildEventList(events, title) {
 // output
 output = '<section class="Quick_links" id="Quick_Links"><ol>';
 
-if (webAPIGroups[0][group].overview) {
-  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[0][group].overview[0] + '</a></strong></li>';
+if (webAPIGroups[group].overview) {
+  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[group].overview[0] + '</a></strong></li>';
 }
 
 if (guides.length > 0) {

--- a/macros/InheritanceDiagram.ejs
+++ b/macros/InheritanceDiagram.ejs
@@ -1,4 +1,4 @@
-<% 
+<%
 /*
   Draws an responsive SVG diagram for the inheritance chain (inverted in rtl)
 
@@ -8,7 +8,7 @@
   $3 - Interface name
 */
 
-var data = string.deserialize(template("InterfaceData"));
+var data = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/interfaces.json");
 var slug = env.slug;
 var result = "";
 // slug is not available in preview mode.
@@ -19,7 +19,7 @@ var mainIF = $3 || slug.replace('Web/API/','').split('/')[0];
 var rtlLocales = ['ar', 'he', 'fa'];
 var inheritanceChain = [mainIF];
 var descendants = [];
-var inh = data[0][mainIF] != undefined ? data[0][mainIF].inh : '';
+var inh = data[mainIF] != undefined ? data[mainIF].inh : '';
 var width = $0 || 600;
 var height = $1 || 70;
 var offset = $2 || 50;
@@ -31,8 +31,8 @@ if (rtlLocales.indexOf(locale) != -1) {
 function getInheritance(inh) {
   if (inh.length > 0) {
     inheritanceChain.unshift(inh);
-    if (data[0].hasOwnProperty(inh)) {
-        var inh = data[0][inh].inh;
+    if (data.hasOwnProperty(inh)) {
+        var inh = data[inh].inh;
         getInheritance(inh);
     }
   }
@@ -47,7 +47,7 @@ getInheritance(inh);
   }
   descendants.sort();
 }
-getDescendants(data[0]):*/
+getDescendants(data):*/
 
 var l = 0;
 
@@ -73,7 +73,7 @@ function lineWithTriangle(x, y, reverse) {
   var str = '';
   if (reverse) {
     str += '<polyline points="'+x+','+(y+24)+'  '+(x-10)+','+(y+19)+'  '+(x-10)+','+(y+29)+'  '+x+','+(y+24)+'" stroke="#D4DDE4" fill="none"/>';
-    x -= 10; 
+    x -= 10;
     str += '<line x1="'+x+'" y1="'+(y+24)+'" x2="'+(x-30)+'" y2="'+(y+24)+'" stroke="#D4DDE4"/>';
   } else {
     str += '<polyline points="'+x+','+(y+24)+'  '+(x+10)+','+(y+19)+'  '+(x+10)+','+(y+29)+'  '+x+','+(y+24)+'" stroke="#D4DDE4" fill="none"/>';

--- a/macros/InterfaceOverview.ejs
+++ b/macros/InterfaceOverview.ejs
@@ -35,10 +35,10 @@ if (slug) {
 
     // Fetch the databases
 
-    var webAPIData = string.deserialize(template('InterfaceData'));
+    var webAPIData = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/interfaces.json");
 
     if (group) {
-        var webAPIGroups = string.deserialize(template('GroupData'));
+        var webAPIGroups = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/groups.json");
     }
 
     var commonl10n = string.deserialize(template('L10n:Common'));
@@ -56,7 +56,7 @@ if (slug) {
     var strAlsoInherits = localString({
       "en-US": "Also inherits $1 from: $2"
     });
-    
+
   // Get translations of strings we need
 
     var text = {
@@ -72,13 +72,13 @@ if (slug) {
 
     // Get the information about this API specifically out of the
     // databases, as well as from the subtree below this page.
-    
+
     var mainIFPages = page.subpagesExpand('/en-US/docs/Web/API/' + mainIF);
     var events = [];
 
-    if (group && webAPIGroups[0][group]) {
+    if (group && webAPIGroups[group]) {
         // ADD HERE ANY CODE NEEDED TO PULL OTHER INFO FROM GROUPDATA
-        events = webAPIGroups[0][group].events || [];
+        events = webAPIGroups[group].events || [];
     }
 
     // Scan the pages and collect the information we need about them
@@ -104,20 +104,20 @@ if (slug) {
             }
         }
     }
-    
+
     collect(mainIFPages);
 
     // Build inheritance information, if any
 
     var inherited = [];
 
-    var impl = webAPIData[0][mainIF] != undefined ? webAPIData[0][mainIF].impl : [];
-    var inh = webAPIData[0][mainIF] != undefined ? webAPIData[0][mainIF].inh : '';
+    var impl = webAPIData[mainIF] != undefined ? webAPIData[mainIF].impl : [];
+    var inh = webAPIData[mainIF] != undefined ? webAPIData[mainIF].inh : '';
 
     if (inh) {
       inherited.push(inh);
     }
-    
+
     impl.forEach(function(value, index, ar) {
       inherited.push(value);
     });
@@ -131,7 +131,7 @@ if (slug) {
         b = bSplit[bSplit.length - 1];
         return a.toLowerCase().localeCompare(b.toLowerCase());
     }
-    
+
     eventHandlers.sort(APISort);
     properties.sort(APISort);
     methods.sort(APISort);
@@ -139,9 +139,9 @@ if (slug) {
     inherited.sort(APISort);
 
     // Build inheritance list string
-    
+
     var inheritanceList = "";
-    
+
     inherited.forEach(function(val, index, ar) {
         inheritanceList += template("domxref", [val]);
         if (index != ar.length-1) {
@@ -168,39 +168,39 @@ if (slug) {
         }
         var result = '<h' + headLevel + '>' + title + '</h' + headLevel + '>';
         var inheritText = '';
-        
+
         if (title != text.Constructor) {
             // If there are any items in the section and there are
             // inherited interfaces:
-            
+
             if (pages.length && inherited.length) {
               inheritText = strAlsoInherits.replace(/\$1/ig,
                             title.toLocaleLowerCase());
               inheritText = inheritText.replace(/\$2/ig, inheritanceList);
             }
-    
+
             // ... if there are no items in the section and no inherited
             // interfaces:
             else if (!pages.length && !inherited.length) {
               inheritText = strNone.replace(/\$1/ig, title.toLocaleLowerCase());
             }
-    
+
             // ... if there are no items in the section but there are inherited
             // interfaces:
-    
+
             else if (!pages.length) {
               inheritText = strInherits.replace(/\$1/ig, title.toLocaleLowerCase());
               inheritText = inheritText.replace(/\$2/ig, inheritanceList);
             }
-    
+
             // ... otherwise, there are items in the section but none inherited,
             // so we don't have any special text at all.
-    
+
             if (inheritText.length) {
               result += '<p><em>' + inheritText + '</em></p>';
             }
         }
-        
+
         result += '<dl>';
 
         for (var i in pages) {
@@ -287,7 +287,7 @@ if (slug) {
 
         return result;
     }
-    
+
     // Time to do the output of the whole thing!
 
     if (ctors.length > 0) {

--- a/macros/eventref.ejs
+++ b/macros/eventref.ejs
@@ -10,8 +10,8 @@ var EventHref = '/' + locale + '/docs/Web/Events';
 var output = "";
 // slug is not available in preview mode.
 if (slug) {
-    
-var groups = string.deserialize(template("GroupData"))[0];
+
+var groups = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/data/master/api/groups.json");
 var event = slug.replace('Web/Events/','').split('/')[0];
 
 


### PR DESCRIPTION
API data (interfaces and groups) change more often and are data, not logic, so they live in the [mdn/data ](https://github.com/mdn/data/tree/master/api) repository. This PR changes the macros that use Template:InterfaceData and Template:GroupData to use the JSON files in the mdn/data repo.

A follow-up that syncs the two data macros with the JSON files over at mdn/data should be created, so that we can then remove the two files here afterwards.

Add `w=1` to the review URL to ignore whitespace.