### PR TITLE
ES3 compressed textures extension name is now _etc (bug 1316778)

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -27,7 +27,7 @@ var lang = env.locale;
 // * Whenever possible, specify a link to the Editor Draft of a spec. This
 //   is the most up-to-date draft. This is not always possible: sometimes the
 //   editor version describe a further level than the published spec: in this
-//   case list both, with the Editor Draft on top. This is the case for CSP 1.0 
+//   case list both, with the Editor Draft on top. This is the case for CSP 1.0
 //   where the ED draft described a further level of CSP and is far from the
 //   Recommendation status.
 //
@@ -801,7 +801,7 @@ var specList = {
     },
     'Shared Memory':{
         name : 'ECMAScript Shared Memory and Atomics',
-        url  : 'http://tc39.github.io/ecmascript_sharedmem/shmem.html' 
+        url  : 'http://tc39.github.io/ecmascript_sharedmem/shmem.html'
     },
     'SIMD': {
         name : 'SIMD',
@@ -1003,9 +1003,9 @@ var specList = {
         name : 'WEBGL_compressed_texture_s3tc',
         url  : 'https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/'
     },
-    'WEBGL_compressed_texture_es3':{
-        name : 'WEBGL_compressed_texture_es3',
-        url  : 'https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_es3/'
+    'WEBGL_compressed_texture_etc':{
+        name : 'WEBGL_compressed_texture_etc',
+        url  : 'https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/'
     },
     'WEBGL_compressed_texture_pvrtc':{
         name : 'WEBGL_compressed_texture_pvrtc',

--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -264,7 +264,7 @@ var status = {
   'OES_vertex_array_object'    : 'REC',
   'WEBGL_color_buffer_float'   : 'REC',
   'WEBGL_compressed_texture_s3tc': 'REC',
-  'WEBGL_compressed_texture_es3': 'Draft',
+  'WEBGL_compressed_texture_etc': 'Draft',
   'WEBGL_compressed_texture_pvrtc': 'Draft',
   'WEBGL_compressed_texture_etc1': 'Draft',
   'WEBGL_compressed_texture_atc': 'Draft',
@@ -379,7 +379,7 @@ var label = {
   }),
   'LC' : mdn.localString({
       'en-US' : 'Last Call Working Draft',
-      'ja'    : '草案の最終案',  
+      'ja'    : '草案の最終案',
       'ru'    : 'Последнее изменение рабочего черновика'
   })
 }


### PR DESCRIPTION
Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1316778
New spec https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/