### PR TITLE
bug 1273028: Update Persona notice

### DIFF
--- a/macros/PersonaDecommissioningNotice.ejs
+++ b/macros/PersonaDecommissioningNotice.ejs
@@ -2,23 +2,17 @@
 
 var output = mdn.localString({
              'en-US' : '<div class="warning">' +
-                       '  <p>Persona is no longer actively developed by Mozilla. Mozilla has committed to operational and security support of the persona.org services until November 30th, 2016.</p>' +
-                       '  <p>On November 30th, 2016, Mozilla will shut down the persona.org services. Persona.org and related domains will be taken offline.</p>' +
-                       '  <p>If you run a website that relies on Persona, you need to implement an alternative login solution for your users before this date.</p>' +
+                       '  <p>On November 30th, 2016, Mozilla shut down the persona.org services. Persona.org and related domains will soon be taken offline.</p>' +
                        '  <p>For more information, see this guide to migrating your site away from Persona:</p>' +
                        '  <p><a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers</a></p>' +
                        '</div>',
              'fr'    : '<div class="warning">' +
-                       '  <p>Persona n\'est plus activement développé par Mozilla. Mozilla effectuera un support opérationnel et des mises à jour de sécurité pour les services liés à persona.org jusqu\'au 30 novembre 2016.</p>' +
                        '  <p>Au 30 novembre 2016, Mozilla arrêtera les services de persona.org. Persona.org et les domaines liés seront mis hors ligne.</p>' +
-                       '  <p>Si gérez un site web qui utilise Persona, vous devrez implémenter une méthode de connexion alternative avant cette date.</p>' +
                        '  <p>Pour plus d\'informations, vous pouvez consulter le guide de migration&nbsp;:</p>' +
                        '  <p><a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers</a></p>' +
                        '</div>',
              'nl'    : '<div class="warning">' +
-                       '  <p>Persona wordt niet meer actief door Mozilla ontwikkeld. Mozilla heeft operationele en beveiligingsondersteuning voor de services van persona.org toegezegd tot 30 november 2016.</p>' +
                        '  <p>Op 30 november 2016 zal Mozilla de services van persona.org stopzetten. Persona.org en gerelateerde domeinen zullen offline worden gehaald.</p>' +
-                       '  <p>Als u een website beheert die afhankelijk is van Persona, dient u voor deze datum een alternatieve oplossing voor aanmelding voor uw gebruikers te implementeren.</p>' +
                        '  <p>Bekijk voor meer informatie deze handleiding voor het migreren van uw website vanaf Persona:</p>' +
                        '  <p><a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers</a></p>' +
                        '</div>'


### PR DESCRIPTION
The Persona service has shutdown. Remove some lines of the notice, and update the English version from future to past tense. The French and Dutch notices were also simplified, but still use the future verb tense.