### PR TITLE
Added SVGCursorElement interface

### DIFF
--- a/macros/InterfaceData.json
+++ b/macros/InterfaceData.json
@@ -111,6 +111,10 @@
     "inh"  : "SVGGeometryElement",
     "impl" : []
   },
+  "SVGCursorElement": {
+    "inh"  : "SVGElement",
+    "impl" : ["SVGURIReference"]
+  },
   "DOMDownload": {
     "inh"  : "EventTarget",
     "impl" : []


### PR DESCRIPTION
Added the `SVGCursorElement` interface definition as [defined in the SVG 2 definition](https://svgwg.org/svg2-draft/interact.html#InterfaceSVGCursorElement).

Sebastian