### PR TITLE
bug 1332886: use encodeURI instead of querystring.escape

### DIFF
--- a/lib/kumascript/server.js
+++ b/lib/kumascript/server.js
@@ -11,7 +11,6 @@ if (newrelic_conf && newrelic_conf.license_key) require('newrelic');
 
 // ### Prerequisites
 var _ = require('underscore'),
-    qs = require('querystring'),
     Memcached = require('memcached'),
     express = require('express'),
     morgan = require('morgan'),
@@ -167,7 +166,7 @@ var Server = ks_utils.Class({
         cache.cacheResponse(req, res, opts, function (req, res) {
             var path = req.params[0],
                 url_tmpl = $this.options.document_url_template,
-                doc_url = ks_utils.tmpl(url_tmpl, {path: qs.escape(path)});
+                doc_url = ks_utils.tmpl(url_tmpl, {path: encodeURI(path)});
 
             var req_opts = {
                 memcached: $this.memcached,

--- a/tests/test-server.js
+++ b/tests/test-server.js
@@ -5,7 +5,6 @@ var util = require('util'),
     _ = require('underscore'),
     nodeunit = require('nodeunit'),
     request = require('request'),
-    qs = require('querystring'),
 
     kumascript = require('..'),
     ks_macros = kumascript.macros,
@@ -64,7 +63,7 @@ module.exports = nodeunit.testCase({
 
     "Fetching 시작하기 from service should be processed as expected": function (test) {
         var expected_fn = __dirname + '/fixtures/documents/시작하기-expected.txt',
-            result_url  = 'http://localhost:9000/docs/' + qs.escape('시작하기');
+            result_url  = 'http://localhost:9000/docs/' + encodeURI('시작하기');
         fs.readFile(expected_fn, 'utf8', function (err, expected) {
             request(result_url, function (err, resp, result) {
                 test.equal(result.trim(), expected.trim());


### PR DESCRIPTION
* use encodeURI instead of querystring.escape to avoid
  escaping slashes