### PR TITLE
Adding WebAssembly JavaScript API to Spec2 and SpecName macros

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -923,6 +923,10 @@ var specList = {
         name : 'Web Animations',
         url  : 'https://w3c.github.io/web-animations/'
     },
+    'WebAssembly JS':{
+        name : 'Web Assembly JavaScript API',
+        url  : 'https://github.com/WebAssembly/design/blob/master/JS.md'
+    },
     'Web Audio API':{
         name : 'Web Audio API',
         url  : 'https://webaudio.github.io/web-audio-api/'

--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -237,6 +237,7 @@ var status = {
   'User Timing Level 2'        : 'ED',
   'vCard'                      : 'RFC',
   'Web Animations'             : 'WD',
+  'WebAssembly JS'             : 'Draft',
   'Web Audio API'              : 'WD',
   'Web Background Sync'        : 'Living',
   'Web Bluetooth'              : 'Draft',


### PR DESCRIPTION
Title says it all — part of the Ongoing WebAssembly docs work.