### PR TITLE
Added the parameter to control the maximal Firefox version back to 'Firefox_for_developers' macro

### DIFF
--- a/macros/Firefox_for_developers.ejs
+++ b/macros/Firefox_for_developers.ejs
@@ -3,12 +3,11 @@
 <%
 /*
  * $0 max version to list
- *
  */
  
-var CURRENT_MAX_VERSION = 50; 
- 
-var maxVersion = CURRENT_MAX_VERSION; /* was $0; replaced by this value to update after each release. */
+var CURRENT_MAX_VERSION = 53; // Needs to be updated on every release
+
+var maxVersion = $0 || CURRENT_MAX_VERSION;
 var minVersion = maxVersion - 30;
 
 if (minVersion < 4) { minVersion = 4 }


### PR DESCRIPTION
This is done to be able to control the versions displayed in the list. @teoli2003 [previously changed that](https://developer.mozilla.org/en-US/docs/Template:Firefox_for_developers$compare?locale=en-US&to=998235&from=594285) to use a constant value, which doesn't make much sense in my eyes, because you will need to adjust the macro on every release and [showing newer Firefox versions under "Older versions"](https://developer.mozilla.org/en-US/Firefox/Releases/49#Older_versions) looks wrong.

I still kept the functionality as fallback if no version is provided, though.

Sebastian