### PR TITLE
Fix bug 1335006

### DIFF
--- a/macros/jsxref.ejs
+++ b/macros/jsxref.ejs
@@ -51,4 +51,13 @@ if (page && page.summary) {
 var code    = !$3 ? '<code>'  : '';
 var endcode = !$3 ? '</code>' : '';
 
-%><a href="<%- URL + $2 %>" title="<%-summary%>"><%- code %><%- str %><%- endcode %></a>
+%>
+<a href="<%- URL + $2 %>" title="<%-summary%>"><%- code %>
+<%
+  if ($3) {
+    %><%=str%><%
+  } else {
+    %><%-str%><%
+  }
+%>
+<%- endcode %></a>

--- a/macros/jsxref.ejs
+++ b/macros/jsxref.ejs
@@ -51,4 +51,4 @@ if (page && page.summary) {
 var code    = !$3 ? '<code>'  : '';
 var endcode = !$3 ? '</code>' : '';
 
-%><a href="<%- URL + $2 %>" title="<%-summary%>"><%- code %><%= str %><%- endcode %></a>
+%><a href="<%- URL + $2 %>" title="<%-summary%>"><%- code %><%- str %><%- endcode %></a>


### PR DESCRIPTION
Change jsxref macro to use <%- %> for the displayed text, so that special
characters like "<" and ">" draw correctly instead of showing up as "&lt;"
etc.