### PR TITLE
Add CSS4 Fonts to spec2.ejs

### DIFF
--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -85,6 +85,7 @@ var status = {
   'CSS4 Basic UI'              : 'WD',
   'CSS4 Cascade'               : 'WD',
   'CSS4 Colors'                : 'ED',
+  'CSS4 Fonts'                 : 'ED',
   'CSS4 Images'                : 'WD',
   'CSS4 Media Queries'         : 'WD',
   'CSS4 Pseudo-Elements'       : 'WD',


### PR DESCRIPTION
For some reason this is already in SpecName.ejs.