### PR TITLE
Webassembly sidebar

### DIFF
--- a/macros/WebAssemblySidebar.ejs
+++ b/macros/WebAssemblySidebar.ejs
@@ -1,7 +1,5 @@
 <%
-var currentSection = $0;
 var locale = env.locale;
-var slug = env.slug;
 var baseURL = "/" + locale + "/docs/WebAssembly/";
 
 var text = mdn.localString({
@@ -39,14 +37,14 @@ var text = mdn.localString({
   </li>
   <li data-default-state="open"><a href="<%=baseURL%>"><%=text['Object_reference']%></a>
     <ol>
-      <li><%- template("jsxref", ["Global_objects/WebAssembly", "WebAssembly"]) %></li>
-      <li><%- template("jsxref", ["Global_objects/WebAssembly/Module", "WebAssembly.Module()"]) %></li>
-      <li><%- template("jsxref", ["Global_objects/WebAssembly/Instance", "WebAssembly.Instance()"]) %></li>
-      <li><%- template("jsxref", ["Global_objects/WebAssembly/Memory", "WebAssembly.Memory()"]) %></li>
-      <li><%- template("jsxref", ["Global_objects/WebAssembly/Table", "WebAssembly.Table()"]) %></li>
-      <li><%- template("jsxref", ["WebAssembly.CompileError()"]) %></li>
-      <li><%- template("jsxref", ["WebAssembly.LinkError()"]) %></li>
-      <li><%- template("jsxref", ["WebAssembly.RuntimeError()"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.Module"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.Instance"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.Memory"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.Table"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.CompileError"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.LinkError"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.RuntimeError"]) %></li>
     </ol>
   </li>
 </ol>

--- a/macros/WebAssemblySidebar.ejs
+++ b/macros/WebAssemblySidebar.ejs
@@ -40,6 +40,13 @@ var text = mdn.localString({
   <li data-default-state="open"><a href="<%=baseURL%>"><%=text['Object_reference']%></a>
     <ol>
       <li><%- template("jsxref", ["Global_objects/WebAssembly", "WebAssembly"]) %></li>
+      <li><%- template("jsxref", ["Global_objects/WebAssembly/Module", "WebAssembly.Module()"]) %></li>
+      <li><%- template("jsxref", ["Global_objects/WebAssembly/Instance", "WebAssembly.Instance()"]) %></li>
+      <li><%- template("jsxref", ["Global_objects/WebAssembly/Memory", "WebAssembly.Memory()"]) %></li>
+      <li><%- template("jsxref", ["Global_objects/WebAssembly/Table", "WebAssembly.Table()"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.CompileError()"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.LinkError()"]) %></li>
+      <li><%- template("jsxref", ["WebAssembly.RuntimeError()"]) %></li>
     </ol>
   </li>
 </ol>

--- a/macros/WebAssemblySidebar.ejs
+++ b/macros/WebAssemblySidebar.ejs
@@ -39,7 +39,7 @@ var text = mdn.localString({
   </li>
   <li data-default-state="open"><a href="<%=baseURL%>"><%=text['Object_reference']%></a>
     <ol>
-      <li><a href="<%=baseURL%>Concepts"><%- template("jsxref", ["WebAssembly"]) %></a></li>
+      <li><%- template("jsxref", ["Global_objects/WebAssembly", "WebAssembly"]) %></li>
     </ol>
   </li>
 </ol>

--- a/macros/WebAssemblySidebar.ejs
+++ b/macros/WebAssemblySidebar.ejs
@@ -1,0 +1,47 @@
+<%
+var currentSection = $0;
+var locale = env.locale;
+var slug = env.slug;
+var baseURL = "/" + locale + "/docs/WebAssembly/";
+
+var text = mdn.localString({
+  'en-US': {
+    'WebAssembly_home_page' : 'WebAssembly home page',
+    'Tutorials' : 'Tutorials',
+      'WebAssembly_concepts' : 'WebAssembly concepts',
+      'Compiling_to_wasm' : 'Compiling from C/C++ to WebAssembly',
+      'JavaScript_API' : 'Using the WebAssembly JavaScript API',
+      'Text_format' : 'Understanding WebAssembly text format',
+      'Text_format_to_wasm' : 'Converting WebAssembly text format to wasm',
+      'Bytecode' : 'Fetching WebAssembly bytecode',
+      'Caching_modules' : 'Caching compiled WebAssembly modules',
+      'Exported_functions' : 'Exported WebAssembly functions',
+    'Object_reference' : 'Object reference'
+  }
+});
+%>
+
+<section class="Quick_links" id="Quick_Links">
+
+<ol>
+  <li data-default-state="open"><a href="<%=baseURL%>"><strong><%=text['WebAssembly_home_page']%></strong></a>
+  <li data-default-state="open"><a href="<%=baseURL%>"><%=text['Tutorials']%></a>
+    <ol>
+      <li><a href="<%=baseURL%>Concepts"><%=text['WebAssembly_concepts']%></a></li>
+      <li><a href="<%=baseURL%>C_to_wasm"><%=text['Compiling_to_wasm']%></a></li>
+      <li><a href="<%=baseURL%>Using_the_JavaScript_API"><%=text['JavaScript_API']%></a></li>
+      <li><a href="<%=baseURL%>Understanding_the_text_format"><%=text['Text_format']%></a></li>
+      <li><a href="<%=baseURL%>Text_format_to_wasm"><%=text['Text_format_to_wasm']%></a></li>
+      <li><a href="<%=baseURL%>Fetching_WebAssembly_bytecode"><%=text['Bytecode']%></a></li>
+      <li><a href="<%=baseURL%>Caching_modules"><%=text['Caching_modules']%></a></li>
+      <li><a href="<%=baseURL%>Exported_functions"><%=text['Exported_functions']%></a></li>
+    </ol>
+  </li>
+  <li data-default-state="open"><a href="<%=baseURL%>"><%=text['Object_reference']%></a>
+    <ol>
+      <li><a href="<%=baseURL%>Concepts"><%- template("jsxref", ["WebAssembly"]) %></a></li>
+    </ol>
+  </li>
+</ol>
+
+</section>


### PR DESCRIPTION
This is a sidebar for the WebAssembly landing page/tutorials, which links to the main WebAssembly page, all the tutorials, and the main reference pages. Let me know if you think this works as a sidebar. One concern I have is that when you click on the links to the reference pages, you'll get the JS side bar on the pages, not this one, as they are in the JS tree. This will create a bit of inconsistency, and I'm not sure how best to deal with that.