### PR TITLE
Updated status of CSS Containment Module to WD

### DIFF
--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -92,7 +92,7 @@ var status = {
   'CSS4 Selectors'             : 'WD',
   'CSS4 Sizing'                : 'ED',
   'CSS4 Text'                  : 'WD',
-  'CSS Containment'            : 'ED',
+  'CSS Containment'            : 'WD',
   'CSS Exclusions'             : 'WD',
   'CSS Flexbox'                : 'CR',
   'CSS Font Rendering'         : 'ED',


### PR DESCRIPTION
According to an [announcement on the www-style mailing list](https://lists.w3.org/Archives/Public/www-style/2017Feb/0086.html), the CSSWG has published a [First Public Working Draft of CSS Containment Module Level 1](https://www.w3.org/TR/css-contain-1/).

Sebastian