### PR TITLE
Remove duplicate "Console API" group

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -271,12 +271,6 @@
                             "error",
                             "contactchange" ]
         },
-        "Console API": {
-            "interfaces": [ "Console" ],
-            "methods": [],
-            "properties": [],
-            "events": []
-        },
         "CSS Counter Styles": {
             "overview":   [ "CSS Counter Styles" ],
             "interfaces": [ "CSSCounterStyleRule" ],


### PR DESCRIPTION
Removed a second, empty, "Console API" group.