### PR TITLE
Use data/master for CSS_Ref and CSSRef

### DIFF
--- a/macros/CSSRef.ejs
+++ b/macros/CSSRef.ejs
@@ -17,12 +17,12 @@ if (slug) {
     var htmlEscape = kuma.htmlEscape;
     var rtlLocales = ['ar', 'he', 'fa'];
 
-    var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/properties.json";
-    var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/at-rules.json";
-    var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/selectors.json";
-    var typesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/types.json";
-    var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/syntaxes.json";
-    var unitsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/units.json";
+    var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/properties.json";
+    var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/at-rules.json";
+    var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/selectors.json";
+    var typesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/types.json";
+    var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxes.json";
+    var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
     var data = {
         properties: mdn.fetchJSONResource(propertiesUrl),
         atRules: mdn.fetchJSONResource(atRulesUrl),

--- a/macros/CSS_Ref.ejs
+++ b/macros/CSS_Ref.ejs
@@ -68,7 +68,7 @@ function compareItems(itemA, itemB) {
 }
 
 function getItemsFromSyntax(syntax) {
-    var items = syntax.match(/[\w\-]+\([\w\-&;,#+*?\[\]\| ]*\)|@[\w\-]+/g) || [];
+    var items = syntax.match(/[\w\-]+\([\w\-<>,#+*?\[\]\| ]*\)|@[\w\-]+/g) || [];
     for (var i = 0; i < items.length; i++) {
         // Remove parameters
         items[i] = items[i].replace(/\(.*?\)/, "()");

--- a/macros/CSS_Ref.ejs
+++ b/macros/CSS_Ref.ejs
@@ -13,12 +13,12 @@
        defaults to ['standard'])
 */
 
-var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/properties.json";
-var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/at-rules.json";
-var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/selectors.json";
-var typesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/types.json";
-var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/syntaxes.json";
-var unitsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/units.json";
+var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/properties.json";
+var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/at-rules.json";
+var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/selectors.json";
+var typesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/types.json";
+var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxes.json";
+var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
 var data = {
     properties: mdn.fetchJSONResource(propertiesUrl),
     atRules: mdn.fetchJSONResource(atRulesUrl),


### PR DESCRIPTION
This PR intends to prepare MDN for the changes made in https://github.com/mdn/data/pull/52.

1) The first commit changes the syntax parsing 
- \&amp;\&amp to && 
- \&lt; \&gt; to < >

There might be more that is necessary. I'm still working through the changes in mdn/data#52.