### PR TITLE
Adding missing CSS layout introduction article to sidebar

### DIFF
--- a/macros/LearnSidebar.ejs
+++ b/macros/LearnSidebar.ejs
@@ -83,6 +83,7 @@ var text = mdn.localString({
         'Assessment_a_cool_looking_box': 'Assessment: A cool-looking box',
       'CSS_layout': 'CSS layout',
         'CSS_layout_overview': 'CSS layout overview',
+        'Introduction' : 'Introduction to CSS layout',
         'Floats': 'Floats',
         'Positioning': 'Positioning',
         'Practical_positioning_examples': 'Practical positioning examples',
@@ -576,6 +577,7 @@ var text = mdn.localString({
   <li data-default-state="<%=currentPageIsUnder('CSS/CSS_layout')%>"><a href="<%=baseURL%>CSS/CSS_layout"><%=text['CSS_layout']%></a>
     <ol>
       <li><a href="<%=baseURL%>CSS/CSS_layout"><%=text['CSS_layout_overview']%></a></li>
+      <li><a href="<%=baseURL%>CSS/CSS_layout/Introduction"><%=text['Introduction']%></a></li>
       <li><a href="<%=baseURL%>CSS/CSS_layout/Floats"><%=text['Floats']%></a></li>
       <li><a href="<%=baseURL%>CSS/CSS_layout/Positioning"><%=text['Positioning']%></a></li>
       <li><a href="<%=baseURL%>CSS/CSS_layout/Practical_positioning_examples"><%=text['Practical_positioning_examples']%></a></li>


### PR DESCRIPTION
Tested on local Kuma installation; looks like it works fine.