### PR TITLE
Fix es7 and latest draft macros

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -499,12 +499,16 @@ var specList = {
         name : 'ECMAScript 2015 (6th Edition, ECMA-262)',
         url  : 'http://www.ecma-international.org/ecma-262/6.0/'
     },
-    'ES7':{
+    'ES2016':{
         name : 'ECMAScript 2016 (ECMA-262)',
         url  : 'http://www.ecma-international.org/ecma-262/7.0/'
     },
+    'ES2017': {
+        name : 'ECMAScript 2017 (ECMA-262)',
+        url  : 'https://tc39.github.io/ecma262/2017/'
+    },
     'ESDraft':{
-        name : 'ECMAScript 2017 Draft (ECMA-262)',
+        name : 'ECMAScript Latest Draft (ECMA-262)',
         url  : 'https://tc39.github.io/ecma262/'
     },
     'ES Int 1.0':{
@@ -1146,7 +1150,8 @@ specList['CSS4 UI'] = specList['CSS4 Basic UI'];
 specList['CSS Scroll Snap Points'] = specList['CSS Scroll Snap'];
 specList['WebSMS'] = specList['Messaging'];
 specList['ES2015'] = specList['ES6'];
-specList['ES2016'] = specList['ES7'];
+specList['ES7'] = specList['ES2016'];
+specList['ES8'] = specList['ES2017'];
 
 // Pull out the name and URL (or use "unknown" if not available)
 

--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -501,7 +501,7 @@ var specList = {
     },
     'ES7':{
         name : 'ECMAScript 2016 (ECMA-262)',
-        url  : 'https://tc39.github.io/ecma262/2016/'
+        url  : 'http://www.ecma-international.org/ecma-262/7.0/'
     },
     'ESDraft':{
         name : 'ECMAScript 2017 Draft (ECMA-262)',

--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -135,7 +135,8 @@ var status = {
   'ES3'                        : 'Standard',
   'ES5.1'                      : 'Standard',
   'ES6'                        : 'Standard',
-  'ES7'                        : 'Standard',
+  'ES2016'                     : 'Standard',
+  'ES2017'                     : 'Standard',
   'ESDraft'                    : 'Draft',
   'ES Int 1.0'                 : 'Standard',
   'ES Int 2.0'                 : 'Standard',
@@ -304,7 +305,8 @@ status['CSS Scroll Snap Points'] = status['CSS Scroll Snap'];
 status['WebSMS'] = status['Messaging'];
 status['Blending'] = status['Compositing'];
 status['ES2015'] = status['ES6'];
-status['ES2016'] = status['ES7'];
+status['ES7'] = status['ES2016'];
+status['ES8'] = status['ES2017'];
 
 var label = {
   'REC': mdn.localString({


### PR DESCRIPTION
`https://tc39.github.io/ecma262/2016/` is not valid anymore and is returning a 404.

The second commit brings some changes you might wanna discuss before merging.