### PR TITLE
Use 'mdn' branch when loading data from mdn/data

### DIFF
--- a/macros/CSSAnimatedProperties.ejs
+++ b/macros/CSSAnimatedProperties.ejs
@@ -6,12 +6,12 @@
 
 // Read all CSSData and extract animated properties
 
-var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/properties.json";
-var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/at-rules.json";
-var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/selectors.json";
-var typesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/types.json";
-var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxes.json";
-var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
+var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/properties.json";
+var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/at-rules.json";
+var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/selectors.json";
+var typesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/types.json";
+var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/syntaxes.json";
+var unitsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/units.json";
 var data = {
     properties: mdn.fetchJSONResource(propertiesUrl),
     atRules: mdn.fetchJSONResource(atRulesUrl),

--- a/macros/CSSRef.ejs
+++ b/macros/CSSRef.ejs
@@ -17,12 +17,12 @@ if (slug) {
     var htmlEscape = kuma.htmlEscape;
     var rtlLocales = ['ar', 'he', 'fa'];
 
-    var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/properties.json";
-    var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/at-rules.json";
-    var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/selectors.json";
-    var typesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/types.json";
-    var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxes.json";
-    var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
+    var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/properties.json";
+    var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/at-rules.json";
+    var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/selectors.json";
+    var typesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/types.json";
+    var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/syntaxes.json";
+    var unitsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/units.json";
     var data = {
         properties: mdn.fetchJSONResource(propertiesUrl),
         atRules: mdn.fetchJSONResource(atRulesUrl),
@@ -185,13 +185,13 @@ if (slug) {
       var result = '<li data-default-state="open"><a href="#"><strong>' + title + '</strong></a><ol>';
       var code    = !noCodeTags ? '<code>'  : '';
       var endcode = !noCodeTags ? '</code>' : '';
-    
+
       for (var i in pages) {
         var aPage = pages[i];
         var summary = escapeQuotes(aPage.summary) || '';
         var url = aPage.url.replace('en-US', locale);
         var title = htmlEscape(aPage.title);
-    
+
         var translated = false;
         if (locale != 'en-US') {
             aPage.translations.forEach(function(translation){
@@ -203,54 +203,54 @@ if (slug) {
                 }
             });
         }
-    
+
         var cta = '';
          if (!translated && locale != 'en-US') {
             cta += ' <a href="'+ url +'$translate" style="opacity:0.5" title="'+ text['title'] + '">' + text['translate'] + '</a>';
         }
-    
+
         result += '<li>';
-    
+
         if (hasTag(aPage, 'Experimental')) {
             result += badges.ExperimentalBadge;
         }
-    
+
         if (hasTag(aPage, 'Non-standard') || hasTag(aPage, 'Non Standard')) {
             result += badges.NonStandardBadge;
         }
-    
+
         if (hasTag(aPage, 'Deprecated')) {
             result += badges.DeprecatedBadge;
         }
-    
+
         if (hasTag(aPage, 'Obsolete')) {
             result += badges.ObsoleteBadge;
             result += '<s class="obsoleteElement">';
         }
-    
+
         if (rtlLocales.indexOf(locale) != -1) {
             result += '<bdi>';
         }
-    
+
         if (slug == aPage.slug) {
             result += '<em>' + code + title + endcode + '</em>'
         } else {
             result += '<a href="' + url + '" title="' + summary + '">' + code + title + endcode + '</a>' + cta;
         }
-    
+
         if (rtlLocales.indexOf(locale) != -1) {
             result += '</bdi>';
         }
-    
+
         if (hasTag(aPage, 'Obsolete')) {
             result += '</s>';
         }
-    
+
         result += '</li>';
       }
-    
+
       result += '</ol></li>';
-    
+
       return result;
     }
 

--- a/macros/CSS_Ref.ejs
+++ b/macros/CSS_Ref.ejs
@@ -13,12 +13,12 @@
        defaults to ['standard'])
 */
 
-var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/properties.json";
-var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/at-rules.json";
-var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/selectors.json";
-var typesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/types.json";
-var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxes.json";
-var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
+var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/properties.json";
+var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/at-rules.json";
+var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/selectors.json";
+var typesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/types.json";
+var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/syntaxes.json";
+var unitsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/units.json";
 var data = {
     properties: mdn.fetchJSONResource(propertiesUrl),
     atRules: mdn.fetchJSONResource(atRulesUrl),
@@ -132,7 +132,7 @@ if (types.some(function(type) { return type === "types"; })) {
             default:
                 item.urlPath = normalizedType;
         }
-        
+
         index[initial].push(item);
     }
 }

--- a/macros/cssinfo.ejs
+++ b/macros/cssinfo.ejs
@@ -11,13 +11,13 @@ var name = $0 || (slug ? slug.split("/").pop().toLowerCase() :
     "preview-wiki-content");
 var atRule = $1;
 
-var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/properties.json";
-var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/at-rules.json";
-var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/selectors.json";
-var typesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/types.json";
-var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxes.json";
-var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
-var localStringsUrl = "https://raw.githubusercontent.com/mdn/data/master/l10n/css.json";
+var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/properties.json";
+var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/at-rules.json";
+var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/selectors.json";
+var typesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/types.json";
+var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/syntaxes.json";
+var unitsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/units.json";
+var localStringsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/l10n/css.json";
 var data = {
     properties: mdn.fetchJSONResource(propertiesUrl),
     atRules: mdn.fetchJSONResource(atRulesUrl),
@@ -202,7 +202,7 @@ function getValueOutput(cssInfo, property, atRule) {
 					var replacedKeywords = keywords.map(function(keyword) {
 						return localize(localStrings, keyword);
 					});
-			
+
 					var output = addAdditionalAppliesToOutput(
 						replacedKeywords.join(", "), property, cssInfo);
 					return parseMacros(output);
@@ -228,9 +228,9 @@ function getValueOutput(cssInfo, property, atRule) {
         var output = localizeString(value);
 
         return parseMacros(addAdditionalAppliesToOutput(output, property,
-            cssInfo)); 
+            cssInfo));
     } else if (typeof value === "boolean") {
-        return localize(localStrings, value ? "yes" : "no"); 
+        return localize(localStrings, value ? "yes" : "no");
     } else if (typeof value === "undefined") {
         return replacePlaceholders(formattedError, [localize(cssLocalStrings,
             "missing")]);

--- a/macros/csssyntax.ejs
+++ b/macros/csssyntax.ejs
@@ -1,4 +1,4 @@
-<% 
+<%
 /*
   Displays the syntax of a CSS property or descriptor
 
@@ -6,12 +6,12 @@
   $1 - @-rule - defaults to the @-rule within the URL
 */
 
-var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/properties.json";
-var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/at-rules.json";
-var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/selectors.json";
-var typesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/types.json";
-var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxes.json";
-var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
+var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/properties.json";
+var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/at-rules.json";
+var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/selectors.json";
+var typesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/types.json";
+var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/syntaxes.json";
+var unitsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/units.json";
 var data = {
     properties: mdn.fetchJSONResource(propertiesUrl),
     atRules: mdn.fetchJSONResource(atRulesUrl),
@@ -47,13 +47,13 @@ var s_where = mdn.localString({
     "fr"   : "où ",
     "ru"   : "где "
 });
-    					 
+
 var s_syntax_value_definition = mdn.localString({
     "en-US": "Value_definition_syntax",
     "de"   : "Wertdefinitionssyntax",
     "fr"   : "Syntaxe_de_d%C3%A9finition_des_valeurs"
 });
-						 
+
 var s_and = mdn.localString({
     "en-US": "and ",
     "de"   : "und ",


### PR DESCRIPTION
It seems impossible to get #132 reviewed soon. However, we want to move forward with mdn/data#52, so I think we should use a branch for now. I think it would only be necessary to load the branched data for the csssyntax macro, but I think it is safer to have all macros load from this branch. 

There are also thoughts around removing the csssyntax macro from MDN (or ideally rewriting it for more user-friendly formal syntax information), but it won't happen any time soon either (1800 pages affected).