### PR TITLE
Update legacy add-ons notice with concrete deprecation release info.

### DIFF
--- a/macros/LegacyAddonsNotice.ejs
+++ b/macros/LegacyAddonsNotice.ejs
@@ -2,16 +2,17 @@
 
 var output = mdn.localString({
     'en-US': '<div class="warning">' +
-        '<p>We are planning to deprecate the use by Firefox add-ons of the techniques described in this document.</p>' +
-        '<p>Don\'t use these techniques to develop new add-ons. Use ' +
-        '<a href="/en-US/Add-ons/WebExtensions">WebExtensions</a> instead.' +
-        '<p>If you maintain an add-on which uses the techniques described here, consider migrating it to use ' +
-        'WebExtensions instead.<p>' +
-        '<p>Add-ons developed using these techniques might not work with multiprocess Firefox (e10s), which is ' +
-        'already the default in Firefox Nightly and Firefox Developer Edition, and will soon be the default in ' +
-        'Beta  and Release versions of Firefox. We have <a ' +
-        'href="/en-US/Add-ons/Working_with_multiprocess_Firefox">documentation on making your add-ons ' +
-        'multiprocess-compatible</a>, but it will be more future-proof for you to migrate to WebExtensions.</p>' +
+        '<p>Add-ons using the techniques described in this document are considered a legacy technology in Firefox. ' +
+        'Don\'t use these techniques to develop new add-ons. Use ' +
+        '<a href="/en-US/Add-ons/WebExtensions">WebExtensions</a> instead. ' +
+        'If you maintain an add-on which uses the techniques described here, consider migrating it to use ' +
+        'WebExtensions.<p>' +
+        '<p><strong>From <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 53</a> onwards, no new legacy add-ons will be accepted on addons.mozilla.org (AMO).</strong></p>' +
+        '<p><strong>From <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 57</a> onwards, WebExtensions will be the only supported extension type, and Firefox will not load other types.</strong></p>' +
+        '<p>Even before Firefox 57, changes coming up in the Firefox platform will break many legacy extensions. ' +
+        'These changes include multiprocess Firefox (e10s), sandboxing, and multiple content processes. ' +
+        'Legacy extensions that are affected by these changes should migrate to WebExtensions if they can. ' +
+        'See the <a href="https://blog.mozilla.org/addons/2017/02/16/the-road-to-firefox-57-compatibility-milestones/">"Compatibility Milestones" document</a> for more.</p>' +
         '<p>A wiki page containing <a href="https://wiki.mozilla.org/Add-ons/developer/communication">' +
         'resources, migration paths, office hours, and more</a>, '+
         'is available to help developers transition to the new technologies.' +

--- a/macros/LegacyAddonsNotice.ejs
+++ b/macros/LegacyAddonsNotice.ejs
@@ -6,7 +6,7 @@ var output = mdn.localString({
         'Don\'t use these techniques to develop new add-ons. Use ' +
         '<a href="/en-US/Add-ons/WebExtensions">WebExtensions</a> instead. ' +
         'If you maintain an add-on which uses the techniques described here, consider migrating it to use ' +
-        'WebExtensions.<p>' +
+        'WebExtensions.</p>' +
         '<p><strong>From <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 53</a> onwards, no new legacy add-ons will be accepted on addons.mozilla.org (AMO).</strong></p>' +
         '<p><strong>From <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 57</a> onwards, WebExtensions will be the only supported extension type, and Firefox will not load other types.</strong></p>' +
         '<p>Even before Firefox 57, changes coming up in the Firefox platform will break many legacy extensions. ' +
@@ -15,7 +15,7 @@ var output = mdn.localString({
         'See the <a href="https://blog.mozilla.org/addons/2017/02/16/the-road-to-firefox-57-compatibility-milestones/">"Compatibility Milestones" document</a> for more.</p>' +
         '<p>A wiki page containing <a href="https://wiki.mozilla.org/Add-ons/developer/communication">' +
         'resources, migration paths, office hours, and more</a>, '+
-        'is available to help developers transition to the new technologies.' +
+        'is available to help developers transition to the new technologies.</p>' +
         '</div>',
     'zh-CN': '<div class="warning">' +
         '<p>我们即将放弃这篇文档中描述的 Firefox 附加组件技术。</p>' +


### PR DESCRIPTION
Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1340403. Since we've now published dates for when legacy add-ons will no longer be supported in Firefox, we should update the deprecation warning on MDN pages with this information.