### PR TITLE
Fixing a small French typo on Index.ejs macro

### DIFF
--- a/macros/Index.ejs
+++ b/macros/Index.ejs
@@ -28,7 +28,7 @@ var l10nPage = mdn.localString({
 
 var l10nTags = mdn.localString({
     "en-US": "Tags and summary",
-    "fr"   : "Êtiquettes et résumé",
+    "fr"   : "Étiquettes et résumé",
     "ja"   : "タグと要約",
     "ru"   : "Теги и описание"
 });


### PR DESCRIPTION
There was a small typo on one of the French translations (wrong accent), this is fixing it.