### PR TITLE
Add Media Session API to GroupData.json.

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1004,7 +1004,7 @@
         "Media Session API": {
             "overview":     [ "Media Session API" ],
             "interfaces":   [ "MediaMetadata",
-                              "MediaSessiohn"],
+                              "MediaSession"],
             "methods":      ["MediaSession.setActionHandler()"],
             "properties":   ["MediaMetadata.album",
                              "MediaMetadata.artist",

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1001,6 +1001,18 @@
                             "started",
                             "devicechange" ]
         },
+        "Media Session API": {
+            "overview":     [ "Media Session API" ],
+            "interfaces":   [ "MediaMetadata",
+                              "MediaSessiohn"],
+            "methods":      ["MediaSession.setActionHandler()"],
+            "properties":   ["MediaMetadata.album",
+                             "MediaMetadata.artist",
+                             "MediaMetadata.artwork",
+                             "MediaMetadata.title",
+                             "MediaSession.metadata",
+                             "MediaSession.playbackState"]
+        },
         "Media Source Extensions": {
             "interfaces": [ "MediaSource",
                             "SourceBuffer",


### PR DESCRIPTION
https://wicg.github.io/mediasession/

Question for whomever reviews this: how do note constructors? I couldn't find an example in the existing file (or not one that was obvious).