### PR TITLE
Refer to HTML 5.1 _REC_, add HTML 5.2 ED

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -615,9 +615,13 @@ var specList = {
         name : 'HTML5',
         url  : 'http://www.w3.org/TR/html5/'
     },
+    'HTML5.2':{
+        name : 'HTML 5.2',
+        url  : 'http://w3c.github.io/html/'
+    },
     'HTML5.1':{
-        name : 'HTML5.1',
-        url  : 'http://www.w3.org/html/wg/drafts/html/master/'
+        name : 'HTML 5.1',
+        url  : 'https://www.w3.org/TR/2016/REC-html51-20161101/'
     },
     'HTML WHATWG':{
         name : 'WHATWG HTML Living Standard',

--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -164,6 +164,7 @@ var status = {
   'HTML5 Web Messaging'        : 'REC',
   'HTML5 W3C'                  : 'REC',
   'HTML5.1'                    : 'REC',
+  'HTML5.2'                    : 'ED',
   'HTML WHATWG'                : 'Living',
   'InputDeviceCapabilities'    : 'ED',
   'IndexedDB'                  : 'REC',


### PR DESCRIPTION
The URI of the former HTML 5.1 draft now refers to the HTML 5.2+ working draft which breaks section links (e.g. `{{SpecName('HTML5.1', '#dom-windowbase64-atob', 'WindowBase64.atob()')}}`).

Refer to the HTML 5.1 Recommendation instead.
(Approach recommended in comment on top is questionable: MDN links to ED, but said “REC” in next column.)

References to sections in SpecName() calls need to be updated.