### PR TITLE
cssinfo: Back to data/master, wrap initial values in <code>

### DIFF
--- a/macros/cssinfo.ejs
+++ b/macros/cssinfo.ejs
@@ -11,13 +11,13 @@ var name = $0 || (slug ? slug.split("/").pop().toLowerCase() :
     "preview-wiki-content");
 var atRule = $1;
 
-var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/properties.json";
-var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/at-rules.json";
-var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/selectors.json";
-var typesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/types.json";
-var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/syntaxes.json";
-var unitsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/css/units.json";
-var localStringsUrl = "https://raw.githubusercontent.com/mdn/data/mdn/l10n/css.json";
+var propertiesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/properties.json";
+var atRulesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/at-rules.json";
+var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/selectors.json";
+var typesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/types.json";
+var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxes.json";
+var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
+var localStringsUrl = "https://raw.githubusercontent.com/mdn/data/master/l10n/css.json";
 var data = {
     properties: mdn.fetchJSONResource(propertiesUrl),
     atRules: mdn.fetchJSONResource(atRulesUrl),
@@ -195,8 +195,8 @@ function getValueOutput(cssInfo, property, atRule) {
             if (propMatches) {
                 return getValueOutput(data.properties[propMatches[1]], property);
             } else {
-                if (property === "initial" && value[0] === "<") {
-                    return value;
+                if (property === "initial" && !localStrings.hasOwnProperty(value)) {
+                    return '<code>' + value + '</code>';
                 } else {
                     var keywords = value.split(", ");
                     var replacedKeywords = keywords.map(function(keyword) {

--- a/macros/cssinfo.ejs
+++ b/macros/cssinfo.ejs
@@ -189,26 +189,26 @@ function getValueOutput(cssInfo, property, atRule) {
                 });
 
             return parseMacros(addAdditionalAppliesToOutput(parsedAnimationTypeValues.join(
-        		localize(localStrings, "listSeparator")), property, cssInfo));
+                localize(localStrings, "listSeparator")), property, cssInfo));
         } else {
-			var propMatches = value.match(/^'(.+?)'$/);
-			if (propMatches) {
-				return getValueOutput(data.properties[propMatches[1]], property);
-			} else {
-				if (property === "initial" && value[0] === "<") {
-					return value;
-				} else {
-					var keywords = value.split(", ");
-					var replacedKeywords = keywords.map(function(keyword) {
-						return localize(localStrings, keyword);
-					});
+            var propMatches = value.match(/^'(.+?)'$/);
+            if (propMatches) {
+                return getValueOutput(data.properties[propMatches[1]], property);
+            } else {
+                if (property === "initial" && value[0] === "<") {
+                    return value;
+                } else {
+                    var keywords = value.split(", ");
+                    var replacedKeywords = keywords.map(function(keyword) {
+                        return localize(localStrings, keyword);
+                    });
 
-					var output = addAdditionalAppliesToOutput(
-						replacedKeywords.join(", "), property, cssInfo);
-					return parseMacros(output);
-				}
-			}
-		}
+                    var output = addAdditionalAppliesToOutput(
+                        replacedKeywords.join(", "), property, cssInfo);
+                    return parseMacros(output);
+                }
+            }
+        }
     } else if (Array.isArray(value)) {
         var output = localize(localStrings, "asLonghands") + "<br/>" +
         "<ul>";


### PR DESCRIPTION
In [properties.json](https://github.com/mdn/data/blob/master/css/properties.json), ``initial`` can have three types of values:

1. A literal value, like ``0`` or ``0% 0%`` or ``none``, as seen on [overflow](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow).    
2. A key into the localization strings file, as seen on [-moz-appearance](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance).
3. A list, each item which matches case 1 or 2.

Previously, case 1 (literal values) were designated with a ``<code>`` wrapper, and this was used in the MDN output. In https://github.com/mdn/data/pull/52, the wrapper was removed, so there is no longer a distinction between case 1 or 2.

This PR uses the presence of the string in the localization strings as a way to distinguish between cases 1 and 2.  If the string is not a localization key, a ``<code>`` wrapper is added for display.  The PR also normalizes tabs to spaces.

Alternatively, a stronger method could be used in properties.json to distinguish between case 1 and 2.

Related to PR #132.