### PR TITLE
LiveSampleURL: Make sure scheme is right on both prod and dev servers

### DIFF
--- a/macros/LiveSampleURL.ejs
+++ b/macros/LiveSampleURL.ejs
@@ -8,7 +8,8 @@
 // $1   The URL from which to pull the sample; if not provided,
 //      the current page is assumed.
 
-var base = env.url;
+var pageUrl = env.url;
+var base = pageUrl;
 
 if ($1 && $1.length > 0) {
     base = $1;
@@ -16,7 +17,23 @@ if ($1 && $1.length > 0) {
 
 base = base.replace('developer.mozilla.org', 'mdn.mozillademos.org');
 
-// HACK: This may be the result of server misconfiguration. 
-base = base.replace('http://', 'https://'); 
+// HACK: This may be the result of server misconfiguration.
+// If we're on production, be sure we use https; otherwise,
+// use the same scheme as pageUrl.
+
+if (pageUrl.indexOf("developer.mozilla.org") != -1) {
+  // Production
+  base = base.replace('http://', 'https://');
+} else if (pageUrl.indexOf("developer.allizom.org") != -1) {
+  // Staging
+  base = base.replace('http://', 'https://');
+} else {
+  // Not production - use the same scheme as the main site
+  if (pageUrl.indexOf("http://") != -1) {
+    base = base.replace('https://', 'http://');
+  } else {
+    base = base.replace('http://', 'https://');
+  }
+}
 %>
 <%= base + '$samples/' + $0 + '?revision=' + env.revision_id %>


### PR DESCRIPTION
Add code to the LiveSampleURL macro to make sure the scheme is right. In production, it should be https. Otherwise, it should match the one used for the main content since macros are loaded from the same domain as the wiki content in dev environments.