### PR TITLE
Make csssyntax.ejs only link to named colors and system colors

### DIFF
--- a/macros/csssyntax.ejs
+++ b/macros/csssyntax.ejs
@@ -14,12 +14,32 @@ var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxe
 var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
 // List types for which we want to link to a description instead of
 // including it in the formal syntax block
+var s_named_color_link = mdn.localString({
+    "en-US": "/docs/Web/CSS/color_value#Color_keywords",
+    "fr"   : "/docs/Web/CSS/Type_color#Les_mots-clés",
+    "de"   : "/docs/Web/CSS/Farben#Farbschlüsselwörter",
+    "es"   : "/docs/Web/CSS/color_value#Color_keywords",
+    "ja"   : "/docs/Web/CSS/color_value#Color_keywords",
+    "nl"   : "/docs/Web/CSS/kleur_waarde#Color_keywords",
+    "pt-BR": "/docs/Web/CSS/color_value#Palavras-chave_de_cores",
+    "zh-CN": "/docs/Web/CSS/color_value#色彩关键字"
+});
+var s_system_color_link = mdn.localString({
+  "en-US": "/docs/Web/CSS/color_value#Color_keywords",
+  "fr"   : "/docs/Web/CSS/Type_color#Couleurs_système",
+  "de"   : "/docs/Web/CSS/Farben#Systemfarben",
+  "es"   : "/docs/Web/CSS/color_value#Colores_de_Sistema",
+  "ja"   : "/docs/Web/CSS/color_value#System_Colors",
+  "nl"   : "/docs/Web/CSS/kleur_waarde#System_Colors",
+  "pt-BR": "/docs/Web/CSS/color_value#System_Colors",
+  "zh-CN": "/docs/Web/CSS/color_value#系统颜色"
+});
 var externallyDescribedTypesData = {
   "named-color": {
-    link: "/docs/Web/CSS/color_value#Color_keywords"
+    link: s_named_color_link
   },
   "deprecated-system-color": {
-    link: "/docs/Web/CSS/color_value#System_Colors"
+    link: s_system_color_link
   }
 };
 var data = {
@@ -281,7 +301,7 @@ function buildLink(match, type) {
 
     // Handle types which we want to describe using a link to a different page
     }  else if (data.externallyDescribedTypes.hasOwnProperty(type)) {
-             return "<a href=\"https://developer.mozilla.org/" + locale + data.externallyDescribedTypes[type].link + "\">&lt;" + type + "&gt;</a>";
+             return "<a href=\"/" + locale + data.externallyDescribedTypes[type].link + "\">&lt;" + type + "&gt;</a>";
 
     // Handle advanced types having their syntax defined within the 'CSSData' template
     } else if (data.syntaxes[type]) {

--- a/macros/csssyntax.ejs
+++ b/macros/csssyntax.ejs
@@ -12,13 +12,24 @@ var selectorsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/select
 var typesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/types.json";
 var syntaxesUrl = "https://raw.githubusercontent.com/mdn/data/master/css/syntaxes.json";
 var unitsUrl = "https://raw.githubusercontent.com/mdn/data/master/css/units.json";
+// List types for which we want to link to a description instead of
+// including it in the formal syntax block
+var externallyDescribedTypesData = {
+  "named-color": {
+    link: "/docs/Web/CSS/color_value#Color_keywords"
+  },
+  "deprecated-system-color": {
+    link: "/docs/Web/CSS/color_value#System_Colors"
+  }
+};
 var data = {
     properties: mdn.fetchJSONResource(propertiesUrl),
     atRules: mdn.fetchJSONResource(atRulesUrl),
     selectors: mdn.fetchJSONResource(selectorsUrl),
     types: mdn.fetchJSONResource(typesUrl),
     syntaxes: mdn.fetchJSONResource(syntaxesUrl),
-    units: mdn.fetchJSONResource(unitsUrl)
+    units: mdn.fetchJSONResource(unitsUrl),
+    externallyDescribedTypes: externallyDescribedTypesData
 };
 var slug = env.slug;
 var locale = env.locale;
@@ -268,6 +279,10 @@ function buildLink(match, type) {
                 localize(commonLocalStrings, "summary");
         }
 
+    // Handle types which we want to describe using a link to a different page
+    }  else if (data.externallyDescribedTypes.hasOwnProperty(type)) {
+             return "<a href=\"https://developer.mozilla.org/" + locale + data.externallyDescribedTypes[type].link + "\">&lt;" + type + "&gt;</a>";
+
     // Handle advanced types having their syntax defined within the 'CSSData' template
     } else if (data.syntaxes[type]) {
         return "<a href=\"#" + type + "\">&lt;" + type + "&gt;</a>";
@@ -337,7 +352,10 @@ function formatTypesSyntax(formattedSyntax, describedTypes) {
                 // Some data type page names have '_value' appended,
                 // which needs to be removed in order to find the syntax
                 var subType = type[1].replace("_value", "");
-                if (data.syntaxes.hasOwnProperty(subType)) {
+                // Describe this type if it exists in "syntaxes" and
+                // it *does not* exist in externallyDescribedTypes
+                if ((data.syntaxes.hasOwnProperty(subType)) &&
+                    (!data.externallyDescribedTypes.hasOwnProperty(subType))) {
                     types.push(subType);
                 }
             }


### PR DESCRIPTION
This is the first of several improvements I'd like to make to the "formal syntax" in CSS pages.

There are lots of color keywords, and currently every CSS property that can take a color value (which is also a lot) gets the same collection of keywords included in its formal syntax. This plays a big role in making the formal syntax a daunting wall of text: https://developer.mozilla.org/en-US/docs/Web/CSS/color#Formal_syntax, https://developer.mozilla.org/en-US/docs/Web/CSS/border#Formal_syntax.

Color keywords are syntactically very simple, so the formal syntax isn't explaining much actual syntax, and it's probably more helpful to link to a page that provides richer information (like a swatch and RGB values) than to just repeat the list on every page.

So that's what this change does: for "named_color" and "deprecated_system_color", it links to the relevant bit of https://developer.mozilla.org/en-US/docs/Web/CSS/color_value, and does not include the full list of values in the formal syntax.

So as not to look like so much of a terrible hack, it does this by adding a new data structure "externallyDescribedTypes": for types that appear in this structure, the macro should link to a resource external to the formal syntax, and not include details in the formal syntax itself.

