### PR TITLE
Ignore node_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,5 @@ docs
 *.a
 *.dylib
 *.un~
-node_modules/fibers
-node_modules/underscore/raw
+node_modules/
 npm-debug.log


### PR DESCRIPTION
This folder is created as part of the SCL3 deployment, and the whole folder should not be checked in.