### PR TITLE
Macro ReleaseChannelInfo: use correct preposition for different date formats

### DIFF
--- a/macros/ReleaseChannelInfo.ejs
+++ b/macros/ReleaseChannelInfo.ejs
@@ -35,10 +35,23 @@ switch(string.tolower($3)) {
     url = "https://www.mozilla.org/en-US/firefox/channel/#firefox";
     break;
 };
-var str = "<p>Firefox " + $0 + ", based on Gecko " + $1 + ", will ship in " + 
-           $2 + ". This article provides information about the changes in " +
+var preposition = "in";
+var spaceCount = 0;
+
+for (var i=0; i<$2.length; i++) {
+  if ($2[i] === " ") {
+    spaceCount++;
+  }
+}
+if (spaceCount >=2) {
+  preposition = "on";
+}
+
+var str = "<p>Firefox " + $0 + ", based on Gecko " + $1 + ", will ship " +
+           preposition + " " + $2 + ". This article provides information about "+
+           "the changes in " +
            "this release that will affect developers. Nightly builds of what " +
-           "will become Firefox " + $0 + " are " + 
+           "will become Firefox " + $0 + " are " +
            web.link(url, 'currently available') + " on the " +
            string.ToUpperFirst($3) + " channel. Some experimental features " +
            "whose release dates are uncertain or undecided are discussed on the " +


### PR DESCRIPTION
Added logic so that if the release date parameter has two or more spaces in it,
it's treated as an exact date. When this happens, the preposition in the text
"will ship in <date>" was previously outputting "will ship in April 27, 2017".
The new logic fixes it to output "will ship on April 27, 2017".