### PR TITLE
Fix issue #176: 'events' property is required in Groupdata

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1063,7 +1063,8 @@
                              "MediaMetadata.artwork",
                              "MediaMetadata.title",
                              "MediaSession.metadata",
-                             "MediaSession.playbackState"]
+                             "MediaSession.playbackState"],
+            "events":        []
         },
         "Media Source Extensions": {
             "interfaces": [ "MediaSource",


### PR DESCRIPTION
Fix issue #176.
Groupdata is a JSON that doesn't live over in mdn/data yet and has no schema to validate the data structures. The EventRef macro apparently relies on having a property called "events" for every group. EventRef shouldn't rely on that property being present and GroupData should be validated by automated tests. Until we have all this, lets fix groupdata by adding the missing property. Sigh.

Regressed in https://github.com/mozilla/kumascript/pull/157 (unseen on prod for like 20 days I guess)