### PR TITLE
Secure context indicators

### DIFF
--- a/macros/secureContextGeneric.ejs
+++ b/macros/secureContextGeneric.ejs
@@ -1,0 +1,30 @@
+<%
+// General macro for inserting a secure context notice, i.e. to mark a
+// feature as only available on secure contexts. See the following page:
+// https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
+//
+// Parameters:
+//  $0  The type of warning indicator: inline/header
+
+var lang = env.locale;
+
+var str_title = mdn.localString({
+  "en-US": "Secure context."
+});
+
+var str_tooltip = mdn.localString({
+  "en-US": "This feature is available only in secure contexts."
+});
+
+var str_desc = mdn.localString({
+  "en-US": "This feature is available only in <a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>secure contexts</a>, in some or all <a href='#Browser_compatibility'>supporting browsers</a>."
+});
+
+if($0 === 'inline') {
+  result = "<span class='inlineIndicator' title='" + str_tooltip + "'>" + str_title + "</span>";
+} else if($0 === 'header') {
+  result = "<div class='overheadIndicator'><p><strong>" + str_title + "</strong><br/>" + str_desc + "</p></div>";
+}
+%>
+
+<%- result %>

--- a/macros/secureContextGeneric.ejs
+++ b/macros/secureContextGeneric.ejs
@@ -21,9 +21,9 @@ var str_desc = mdn.localString({
 });
 
 if($0 === 'inline') {
-  result = "<span class='inlineIndicator' title='" + str_tooltip + "'>" + str_title + "</span>";
+  result = "<span class='inlineIndicator secureContexts' title='" + str_tooltip + "'>" + str_title + "</span>";
 } else if($0 === 'header') {
-  result = "<div class='overheadIndicator'><p><strong>" + str_title + "</strong><br/>" + str_desc + "</p></div>";
+  result = "<div class='overheadIndicator secureContexts'><p><strong>" + str_title + "</strong><br/>" + str_desc + "</p></div>";
 }
 %>
 

--- a/macros/secureContextGeneric.ejs
+++ b/macros/secureContextGeneric.ejs
@@ -9,11 +9,11 @@
 var lang = env.locale;
 
 var str_title = mdn.localString({
-  "en-US": "Secure context."
+  "en-US": "Secure context"
 });
 
 var str_tooltip = mdn.localString({
-  "en-US": "This feature is available only in secure contexts."
+  "en-US": "This feature is available only in secure contexts"
 });
 
 var str_desc = mdn.localString({

--- a/macros/secureContextGeneric.ejs
+++ b/macros/secureContextGeneric.ejs
@@ -13,11 +13,11 @@ var str_title = mdn.localString({
 });
 
 var str_tooltip = mdn.localString({
-  "en-US": "This feature is available only in secure contexts"
+  "en-US": "This feature is available only in secure contexts (HTTPS)"
 });
 
 var str_desc = mdn.localString({
-  "en-US": "This feature is available only in <a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>secure contexts</a>, in some or all <a href='#Browser_compatibility'>supporting browsers</a>."
+  "en-US": "This feature is available only in <a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>secure contexts</a> (HTTPS), in some or all <a href='#Browser_compatibility'>supporting browsers</a>."
 });
 
 if($0 === 'inline') {

--- a/macros/secureContext_header.ejs
+++ b/macros/secureContext_header.ejs
@@ -1,0 +1,8 @@
+<%
+// Macro for inserting a block secure context header notice, i.e. to mark a
+// feature as only available on secure contexts. See the following page:
+// https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
+
+%>
+
+<%-template('secureContextGeneric', ["header"])%>

--- a/macros/secureContext_inline.ejs
+++ b/macros/secureContext_inline.ejs
@@ -1,0 +1,8 @@
+<%
+// Macro for inserting an inline secure context notice, i.e. to mark a
+// feature as only available on secure contexts. See the following page:
+// https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
+
+%>
+
+<%-template('secureContextGeneric', ["inline"])%>


### PR DESCRIPTION
This PR contains some macros for creating both inline and block/header notices to allow writers to indicate that a page or list item describes a feature that is available only in secure contexts (see https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).

I have tested the macros on my local Kuma Docker install, and they seem to work fine. In terms of reviewing this patch, I think we need:

1. A writer to comment on whether the wording is appropriate.
2. A developer to comment on whether the implementation is OK, and also to let me know about the best process for asking about getting some custom styling for these notices (e.g. a specific color, and a suitable icon, perhaps?) That can be a later enhancement; just something basic will do for now.

