### PR TITLE
Update WebExtBrowserCompat.ejs to handle manifest.json

### DIFF
--- a/macros/WebExtBrowserCompat.ejs
+++ b/macros/WebExtBrowserCompat.ejs
@@ -23,31 +23,31 @@ The tableFromArgument() function takes a single argument, which must be
 a string that traces a path through the browser compat data.
 The string may be either of:
 
-    * "data.webextensions.manifest". In this case the function generates an
+    * "webextensions.manifest". In this case the function generates an
     agregate table for all manifest keys.
 
-    * "data.webextensions.manifest.<KEY-NAME>", where <KEY-NAME> is the name
+    * "webextensions.manifest.<KEY-NAME>", where <KEY-NAME> is the name
     of a manifest key, like "applications" or "content_scripts". In this case
     the function generates a table for the given manifest key.
 */
 function tableFromArgument(path) {
-  var path = $0; // "data.webextensions.manifest.applications"
+  var path = $0; // "webextensions.manifest.applications"
   var pathComponents = path.split(".");
   // first, validate the argument
-  // there must be at least "data", "webextensions", "manifest"
-  if (pathComponents.length < 3 ||
-    !((pathComponents[0] === "data") && (pathComponents[1] === "webextensions") && (pathComponents[2] === "manifest"))) {
+  // there must be at least "webextensions" and "manifest"
+  if (pathComponents.length < 2 ||
+    !((pathComponents[0] === "webextensions") && (pathComponents[1] === "manifest"))) {
     throw "If an argument is given it must point to WebExtensions manifest data.";
   }
   const manifestDataUrl = "https://raw.githubusercontent.com/mdn/browser-compat-data/master/webextensions/manifest-keys.json";
   // if the argument does not specify a manifest key, generate the aggregate table
-  if (pathComponents.length === 3) {
-    const manifestBaseUrl = "Add-ons/WebExtensions/manifest.json/";
+  if (pathComponents.length === 2) {
+    const manifestBaseUrl = "Add-ons/WebExtensions/manifest.json";
     compatJson = mdn.fetchJSONResource(manifestDataUrl).data.webextensions.manifest;
     return template("WebExtBrowserCompatTable", [compatJson, manifestBaseUrl]);
   } else {
   // otherwise, use the given manifest key to generate the feature table
-    compatJson = mdn.fetchJSONResource(manifestDataUrl).data.webextensions.manifest[pathComponents[3]];
+    compatJson = mdn.fetchJSONResource(manifestDataUrl).data.webextensions.manifest[pathComponents[2]];
     return template("WebExtBrowserCompatTable", [compatJson]);
   }
 }

--- a/macros/WebExtBrowserCompat.ejs
+++ b/macros/WebExtBrowserCompat.ejs
@@ -1,13 +1,60 @@
 <%
 
-/*
+/**
 WebExtBrowserCompat.ejs
 -----------------------
 Use this macro to insert the appropriate WebExtension compat table for the
 current page.
 
-It transforms the URL of the current page into a path through the compat
-data, and uses this path to retrieve the appropriate bit of data.
+It takes one optional argument.
+
+* If the argument is given, the macro calls tableFromArgument(), which uses
+the argument to get the right chunk of JSON data for the table. Currently
+this function only supports tables for manifest.json keys.
+
+* If the argument is omitted, the macro calls tableFromSlug(), which uses
+the slug of the current page to get the right chunk of JSON data for the
+table. The no-argument form is only allowed on pages under
+"Add-ons/WebExtensions/API/".
+*/
+
+/**
+The tableFromArgument() function takes a single argument, which must be
+a string that traces a path through the browser compat data.
+The string may be either of:
+
+    * "data.webextensions.manifest". In this case the function generates an
+    agregate table for all manifest keys.
+
+    * "data.webextensions.manifest.<KEY-NAME>", where <KEY-NAME> is the name
+    of a manifest key, like "applications" or "content_scripts". In this case
+    the function generates a table for the given manifest key.
+*/
+function tableFromArgument(path) {
+  var path = $0; // "data.webextensions.manifest.applications"
+  var pathComponents = path.split(".");
+  // first, validate the argument
+  // there must be at least "data", "webextensions", "manifest"
+  if (pathComponents.length < 3 ||
+    !((pathComponents[0] === "data") && (pathComponents[1] === "webextensions") && (pathComponents[2] === "manifest"))) {
+    throw "If an argument is given it must point to WebExtensions manifest data.";
+  }
+  const manifestDataUrl = "https://raw.githubusercontent.com/mdn/browser-compat-data/master/webextensions/manifest-keys.json";
+  // if the argument does not specify a manifest key, generate the aggregate table
+  if (pathComponents.length === 3) {
+    const manifestBaseUrl = "Add-ons/WebExtensions/manifest.json/";
+    compatJson = mdn.fetchJSONResource(manifestDataUrl).data.webextensions.manifest;
+    return template("WebExtBrowserCompatTable", [compatJson, manifestBaseUrl]);
+  } else {
+  // otherwise, use the given manifest key to generate the feature table
+    compatJson = mdn.fetchJSONResource(manifestDataUrl).data.webextensions.manifest[pathComponents[3]];
+    return template("WebExtBrowserCompatTable", [compatJson]);
+  }
+}
+
+/**
+This function transforms the URL of the current page into a path through
+the compat data, and uses this path to retrieve the appropriate bit of data.
 For example:
 
 https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/alarms
@@ -25,34 +72,42 @@ https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/devtools.panels
 It then passes the compat data into "WebExtBrowserCompatTable", which
 builds the table.
 
-This macro may only be called from pages under "Add-ons/WebExtensions/API/".
-It takes no arguments.
+This function may only be called from pages under "Add-ons/WebExtensions/API/".
 */
+function tableFromSlug() {
+  const url = "https://raw.githubusercontent.com/mdn/browser-compat-data/master/webextensions/javascript-apis.json";
+  const webExtAPIBaseUrl = "Add-ons/WebExtensions/API/";
 
-const url = "https://raw.githubusercontent.com/mdn/browser-compat-data/master/webextensions/javascript-apis.json";
-const webExtAPIBaseUrl = "Add-ons/WebExtensions/API/";
+  // Pages that include this macro must be under
+  // the "Add-ons/WebExtensions/API/" hierarchy.
+  // So first, let's get the part of the URL following that subpath, or fail.
+  var components = env.slug.split(webExtAPIBaseUrl);
+  if (components.length < 2) {
+    throw "If no arguments are given, then this macro can only be called from pages under \"Add-ons/WebExtensions/API/\"";
+  }
 
-// Pages that include this macro must be under
-// the "Add-ons/WebExtensions/API/" hierarchy.
-// So first, let's get the part of the URL following that subpath, or fail.
-var components = env.slug.split(webExtAPIBaseUrl);
-if (components.length < 2) {
-  throw "This macro can only be called from pages under \"Add-ons/WebExtensions/API/\"";
+  // Now we're looking at a subpath like:
+  // "Alarms" or "Alarms/clear" or "storage/StorageArea/get"
+  // or even "devtools.panels/ExtensionPanel"
+  // So split this subpath on either "/" or ".":
+  pathPieces = components[1].split(/[\.//]/);
+
+  // Now we can use pathPieces to walk through the compat data
+  var compatJson = mdn.fetchJSONResource(url).data.webextensions.api;
+  for (piece of pathPieces) {
+    compatJson = compatJson[piece];
+  }
+
+  return template("WebExtBrowserCompatTable", [compatJson, env.slug]);
 }
-  
-// Now we're looking at a subpath like:
-// "Alarms" or "Alarms/clear" or "storage/StorageArea/get"
-// or even "devtools.panels/ExtensionPanel"
-// So split this subpath on either "/" or ".":
-pathPieces = components[1].split(/[\.//]/);
 
-// Now we can use pathPieces to walk through the compat data
-var compatJson = mdn.fetchJSONResource(url).data.webextensions.api;  
-for (piece of pathPieces) {
-  compatJson = compatJson[piece];
+var output;
+
+if ($0) {
+  output = tableFromArgument($0);
+} else {
+  output = tableFromSlug();
 }
-
-var output = template("WebExtBrowserCompatTable", [compatJson, env.slug]);
 
 %>
 <%-output%>


### PR DESCRIPTION
This updates the WebExtBrowserCompat.ejs macro so we can use it to embed compatibility tables for [manifest.json](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json) keys.

I've thought a bit about the best way to implement this.

On the one hand, I agree that it's better for these macros to be explicitly given an identifier for the data that they should include, rather than the "magic" approach where they try to figure out the data from the page slug (see https://github.com/mozilla/kumascript/pull/173#issuecomment-300281099). The main reasons for not doing this already for the JS APIs are:

1. we have a significant number of pages (380-odd) that already include `{{WebExtBrowserCompat}}` without any arguments, and updating them would be a pain
2. we don't yet have a common macro for all tables, so any change I make now will probably need to be made again.

However, we don't yet have any calls to  `{{WebExtBrowserCompat}}`  from the manifest.json docs, so  reason (1) doesn't apply. Also, there aren't nearly as many pages for the manifest.json docs, so (2) has less force. So using explicit arguments here seems like a good plan.

On the other hand, I didn't want to create another new macro, which would probably be transitional until we have a single common macro for all domains.

So, I've updated `{{WebExtBrowserCompat}}` to accept an optional argument, which explicitly identifies a chunk of JSON. This is used for manifest keys. If the argument is omitted, the macro behaves exactly as it did before: expects to be called from under "Add-ons/WebExtensions/API/", and tries to index into the JSON data using information derived from the slug.