### PR TITLE
bug 1328839: enable "require" of npm packages

### DIFF
--- a/lib/kumascript/api.js
+++ b/lib/kumascript/api.js
@@ -227,7 +227,7 @@ var APIContext = ks_utils.Class({
                 // require() expects to run inside a Fiber
                 Fiber(function () {
                     var tmpl_name = autorequire[install_name],
-                        exports = $this.require(tmpl_name);
+                        exports = $this.require_macro(tmpl_name);
                     setCaseVariantAliases($this, install_name, exports);
                     fe_next();
                 }).run();
@@ -340,30 +340,34 @@ var APIContext = ks_utils.Class({
         return output;
     },
 
-    // #### require(path)
+    // #### require_macro(name)
     //
-    // Attempts to load and execute a template which, as a side effect, can
-    // populate an exports object in quasi-CommonJS style. The template output
-    // is ignored.
-    require: function (name) {
-
-        // Use an internal cache, so that repeated require() calls reuse the
-        // previously loaded results.
+    // This is a request to load a Kumascript macro as a module. It attempts
+    // to load and execute the named macro which, as a side effect, should
+    // populate an "exports" or "module.exports" object in nodejs style (the
+    // macro output is ignored).
+    require_macro: function (name) {
+        // Use an internal cache, so that repeated require() calls
+        // reuse the previously loaded results.
         if (!(name in this._require_cache)) {
             var clone_ctx = _.clone(this);
 
-            // Let's pretend we're following CommonJS module conventions
+            // Let's pretend we're following nodejs module conventions.
             clone_ctx.module = { exports: {} };
             clone_ctx.exports = clone_ctx.module.exports;
 
-            // clone_ctx is just like calling a template, only we ignore the output
-            // and return the side effect of populating exports.
+            // We ignore the output and return the side effect of
+            // populating the "module.exports" object.
             clone_ctx.template(name, []);
             this._require_cache[name] = clone_ctx.module.exports;
         }
-
         return this._require_cache[name];
-    }
+    },
+
+    // #### require(name)
+    //
+    // Load an npm package (the real "require" has its own cache).
+    require: require
 
 });
 

--- a/macros/DekiScript-Page.ejs
+++ b/macros/DekiScript-Page.ejs
@@ -1,8 +1,8 @@
 <% module.exports = buildAPI({
-    
+
     initialize: function (options) {
         BaseAPI.prototype.initialize.call(this, options);
-        
+
         // Incomplete list of Page vars, but probably good enough.
         // See also: <http://developer.mindtouch.com/en/docs/DekiScript/Reference/Wiki_Functions_and_Variables/Page>
         this.setVars({
@@ -16,15 +16,15 @@
             uri: env.url
         });
     },
-    
+
     // Determines whether or not the page has the specified tag. Returns true
     // if it does, otherwise false. This is case-insensitive.
     //
     // Parameters:
-    //  
-    hasTag: function(aPage, aTag) {        
+    //
+    hasTag: function(aPage, aTag) {
         // First, return false at once if there are no tags on the page
-        
+
         if (aPage.tags == undefined || aPage.tags == null || aPage.tags.length == 0) {
             return false;
         }
@@ -34,13 +34,13 @@
         var theTag = aTag.toLowerCase();
 
         // Now look for a match
-        
+
         for (var i=0; i<aPage.tags.length; i++) {
             if (aPage.tags[i].toLowerCase() == theTag) {
                 return true;
             }
         }
-        
+
         return false;
     },
 
@@ -60,7 +60,7 @@
         if(depth_check  >= 0) {
             url += '?depth=' + depth_check;
         }
-        var mdn = require('MDN:Common');
+        var mdn = require_macro('MDN:Common');
         var subpages = mdn.fetchJSONResource(url);
         var result = [];
         if (subpages != null) {
@@ -85,14 +85,14 @@
         } else {
             url = env.url + '$children';
         }
-        
+
         url += '?expand';
-        
+
         var depth_check = parseInt(depth);
         if(depth_check  >= 0) {
             url += '&depth=' + depth_check;
         }
-        var mdn = require('MDN:Common');
+        var mdn = require_macro('MDN:Common');
         var subpages = mdn.fetchJSONResource(url);
         var result = [];
         if (subpages != null) {
@@ -104,7 +104,7 @@
         }
         return result;
     },
-    
+
     // If reverse is non-zero, the sort is backward
     subPagesSort: function (pages, reverse) {
         if (reverse == 0) {
@@ -161,12 +161,12 @@
 			return aa.length - bb.length;
 		}
     },
-    
+
     // Flatten subPages list
     subPagesFlatten: function (pages) {
-        
+
         var output = [];
-        
+
         process_array(pages);
 
         return output;
@@ -186,7 +186,7 @@
             }
         }
     },
-    
+
     // If ordered is true, the output is an <ol> instead of <ul>
     //
     // Special note: If ordered is true, pages whose locale differs from
@@ -194,17 +194,17 @@
     // localizations showing up in navigation.
     subPagesFormatList: function (pages, ordered) {
         return process_array(pages, ordered != 0);
-        
+
         function process_array(arr, ordered) {
             var result = '';
             var openTag = '<ul>';
             var closeTag = '</ul>';
-            
+
             if (ordered) {
                 openTag = '<ol>';
                 closeTag = '</ol>';
             }
-            
+
             if(arr.length) {
                 result += openTag;
                 arr.forEach(function(item) {
@@ -217,15 +217,15 @@
                         result += item.title;
                     }
                     result += process_array(item.subpages || [], ordered) + '</li>';
-                    
+
                 });
                 result += closeTag;
             }
             return result;
         }
-        
+
     },
-    
+
     translations: function (path) {
         var url = '';
         if (path) {
@@ -234,7 +234,7 @@
         } else {
             url = env.url + '$json';
         }
-        var mdn = require('MDN:Common');
+        var mdn = require_macro('MDN:Common');
         var json = mdn.fetchJSONResource(url);
         var result = [];
         if (json != null) {
@@ -242,5 +242,5 @@
         }
         return result;
     },
-    
+
 }); %>

--- a/macros/DekiScript-Wiki.ejs
+++ b/macros/DekiScript-Wiki.ejs
@@ -1,6 +1,6 @@
 <% var wiki = module.exports = buildAPI({
     /*
-    * Given a MediaWiki path attempt to update it to a Kuma path 
+    * Given a MediaWiki path attempt to update it to a Kuma path
     * This is not a DekiScript function
     */
     kumaPath: function(in_path) {
@@ -12,7 +12,7 @@
         var path = '/' + pathLang + path_strip.replace(/^(\/?\w{2}(?:[-|_]\w{2})?)?\/(?:docs\/)?/i,'/docs/').replace(/ /g,'_').replace(/%20/g,'_');
         return path;
     },
-    
+
     //
     // Given a string, escape any quotes within it so it can be
     // passed to other functions.
@@ -40,8 +40,8 @@
         var base_url = p.protocol + '//' + p.host;
 
         if (path.indexOf('/docs') == -1) {
-            // HACK: If this looks like a legacy wiki URL, throw /en-US/docs 
-            // in front of it. That will trigger the proper redirection logic 
+            // HACK: If this looks like a legacy wiki URL, throw /en-US/docs
+            // in front of it. That will trigger the proper redirection logic
             // until/unless URLs are corrected in templates
             base_url += '/en-US/docs';
         }
@@ -55,22 +55,22 @@
 
         return base_url + path;
     },
-    
+
     // Check if the given wiki page exists.
     // [See also](http://developer.mindtouch.com/en/docs/DekiScript/Reference/Wiki_Functions_and_Variables/Wiki.PageExists)
     pageExists: function (path) {
         // Temporarily disabling this.
         // See: https://bugzilla.mozilla.org/show_bug.cgi?id=775590#c4
         return true;
-        
+
         var key = 'kuma:page_exists:' + md5(path.toLowerCase());
-        
-        // This is an experiment to exempt wiki.pageExists 
+
+        // This is an experiment to exempt wiki.pageExists
         // from shift-refresh cache busting:
-        var mdn = require('MDN:Common');
+        var mdn = require_macro('MDN:Common');
 
         //return cacheFn(key, 3600, function (next) {
-        return mdn.cacheFnIgnoreCacheControl(key, 3600, function (next) {            
+        return mdn.cacheFnIgnoreCacheControl(key, 3600, function (next) {
             var opts = { method: 'HEAD', url: wiki.buildAbsoluteURL(path) };
 
             try {
@@ -86,7 +86,7 @@
             }
         });
     },
-    
+
     // Adjusts the visibility and heading levels of the specified HTML.
     //
     // The show parameter indicates whether or not the top level heading/title
@@ -121,14 +121,14 @@
         }
 
         if (show) { return html; }
-        
+
         // Rip out the section header
         if (html) { html = html.replace(/^<h\d[^>]*>[^<]*<\/h\d>/ig,"") + ""; }
-        
+
         return html;
     },
-        
-    // Retrieve the content of a document for inclusion, optionally filtering 
+
+    // Retrieve the content of a document for inclusion, optionally filtering
     // for a single section.
     //
     // Doesn't support the revision parameter offered by DekiScript
@@ -141,7 +141,7 @@
         }
         var key = 'kuma:include:' + md5(key_text);
 
-        var regenerate = function (next) {            
+        var regenerate = function (next) {
             var params = ['raw=1', 'macros=1', 'include=1'];
 
             if (section) { params.push('section='+encodeURIComponent(section)); }
@@ -169,7 +169,7 @@
             }
         };
         if (ignore_cache_control) {
-            var mdn = require('MDN:Common');
+            var mdn = require_macro('MDN:Common');
             return mdn.cacheFnIgnoreCacheControl(key, 3600, regenerate);
         } else {
             return cacheFn(key, 3600, regenerate);
@@ -205,7 +205,7 @@
             }
         });
     },
-     
+
     // Returns a list of the headings for the specified page.
     // Each item in the returned list is an object with these fields:
     //
@@ -216,14 +216,14 @@
     //
     //  path    The path of the page whose headings should be returned
     //  depth   The maximum header level to return
-    
+
     getHeadings: function(path, depth) {
         var html = wiki.page(path);
-                
+
         if (!html || html.length == 0) {
             return NULL;
         }
-        
+
         if (!depth) {
             depth = 3;
         }
@@ -231,11 +231,11 @@
         var re = /\<h([1-6]).*?\>(.+)\<\/h[1-6]\>/gi;
         var result;
         var list = [];
-        
+
         while ((result = re.exec(html))) {
             var theLevel = result[1];
             var theTitle = result[2];
-            
+
             if (theLevel <= depth) {
                 var obj = {level: theLevel, title: theTitle };
                 list.push(obj);
@@ -253,7 +253,7 @@
 
         return out;
     },
- 
+
     // A link to the wiki page that you will add, that will be in a different language.
     // [See also](http://developer.mindtouch.com/en/docs/DekiScript/Reference/Wiki_Functions_and_Variables/Wiki.Languages)
     languages: function (langs) {
@@ -274,24 +274,24 @@
     // Special note: If ordered is true, pages whose locale differ from
     // the current page's locale are omitted, to work around misplaced
     // localizations showing up in navigation.
-    
+
     tree: function(path, depth, self, reverse, ordered) {
-        var page = require('DekiScript:Page');
-        
+        var page = require_macro('DekiScript:Page');
+
         // If the path ends with a slash, remove it.
-        
+
         if (path.substr(-1, 1) === '/') {
             path = path.slice(0, -1);
         }
-        
+
         var pages = page.subpages(path, depth, self);
-        
+
         if (reverse == 0) {
             pages.sort(alphanumForward);
         } else {
             pages.sort(alphanumBackward);
         }
-        
+
         return process_array(null, pages, ordered != 0);
 
     	function chunkify(t) {
@@ -344,12 +344,12 @@
             var result = '';
             var openTag = '<ul>';
             var closeTag = '</ul>';
-            
+
             if (ordered) {
                 openTag = '<ol>';
                 closeTag = '</ol>';
             }
-            
+
             if(arr.length) {
                 result += openTag;
 
@@ -358,20 +358,20 @@
                 if (folderItem != null && ordered) {
                     result += '<li><a href="' + folderItem.url + '">' + kuma.htmlEscape(folderItem.title) + '</a></li>';
                 }
-                
+
                 // Now dive into the child items
-                
+
                 arr.forEach(function(item) {
                     if (!item) { return; }
                     if (ordered && (item.locale != env.locale)) { return; }
                     result += '<li><a href="' + item.url + '">' + kuma.htmlEscape(item.title) + '</a>' +
                               process_array(item, item.subpages || [], ordered) + '</li>';
-                    
+
                 });
                 result += closeTag;
             }
             return result;
-        }   
+        }
     }
-     
+
 }); %>

--- a/macros/DocStatus.ejs
+++ b/macros/DocStatus.ejs
@@ -12,7 +12,7 @@
 //  $6  -  (optional) Tags that all pages should have. (OR logic)
 
 /*** Module loading ***/
-var MDN = require("MDN:Common");
+var MDN = require_macro("MDN:Common");
 
 /*** Variables ***/
 var slug = $0;
@@ -159,7 +159,7 @@ function missingTags(tagList, requiredTags) {
       if (tagList[i] == 'Index') return 0;
       for (var j = 0; j < requiredTags.length; j++) {
           if (tagList[i].toLowerCase() == requiredTags[j].toLowerCase()) {
-              yay++;                                                                     
+              yay++;
           }
       }
    }
@@ -195,8 +195,8 @@ function daysBetween(date1, date2) {
   var d1ms = date1.getTime();
   var d2ms = date2.getTime();
   var diff = d2ms - d1ms;
-    
-  return Math.round(diff/aDay); 
+
+  return Math.round(diff/aDay);
 }
 
 
@@ -207,9 +207,9 @@ function collect(page) {
     var cleanTitle = page.title.replace('<','&lt;').replace('>','&gt;');
     var pageurl = page.url;
     var rgx = /needs[A-Za-z0-9]+/gi;
-            
+
     if (hasNoTags(page.tags)) {
-        metrics.noTags.counter++; 
+        metrics.noTags.counter++;
         output.noTags.push({title: cleanTitle, url: pageurl});
     }
     if (containsNeedsWorkTag(page.tags)) {
@@ -221,7 +221,7 @@ function collect(page) {
             }
         });
     }
-    if (hasReviewTag(page.review_tags, 'editorial')) { 
+    if (hasReviewTag(page.review_tags, 'editorial')) {
         metrics.editorialReviews.counter++;
         output.editorialReviews.push({title: cleanTitle, url: pageurl});
     }
@@ -252,7 +252,7 @@ function getPages(pageList) {
             } else {
                 collect(pageList[i]);
             }
-            
+
             var subpage = getPages(pageList[i].subpages);
         }
     }
@@ -341,7 +341,7 @@ if (metrics.hasOwnProperty(obj) && typeof metrics[obj] !== 'undefined') {
     var color = "rgb(204, 255, 153)";
     if (percent >= 5) { color = "rgb(255, 255, 153)" }
     if (percent >= 10) { color = "rgb(255, 204, 204)" }
-    if (obj == 'pages') { 
+    if (obj == 'pages') {
 %>
     <td><%=metrics.pages.counter%></td>
 <% } else { %>
@@ -358,7 +358,7 @@ if (metrics.hasOwnProperty(obj) && typeof metrics[obj] !== 'undefined') {
 <% /*** page metrics ***/ %>
 
 
-<% 
+<%
 
 for (var obj in output) {
 if (output.hasOwnProperty(obj) && typeof metrics[obj] != 'undefined' && metrics[obj].counter > 0) {
@@ -387,8 +387,8 @@ if (output.hasOwnProperty(obj) && typeof metrics[obj] != 'undefined' && metrics[
 <% if (Array.isArray(result)) {
     for (i=0; i < result.length; i++) { %>
     <li><a href='<%=result[i].url%>'><%=result[i].title%></a><% if (result[i].note != undefined) { %><br/><small><%=result[i].note%></small><% } %></li>
-<%  } 
-} else { 
+<%  }
+} else {
     for (ntag in result) {
         if (result.hasOwnProperty(ntag)) {
 %>
@@ -411,13 +411,13 @@ if (output.hasOwnProperty(obj) && typeof metrics[obj] != 'undefined' && metrics[
 
 <% /*** Bug lists ***/ %>
 
-<% if (bzddn && bzddn != '') { 
+<% if (bzddn && bzddn != '') {
     if (ddnBugs.bugs.length > 0) {
         var bzLink = 'https://bugzilla.mozilla.org/buglist.cgi?bug_id=';
 %>
     <h2 id="Dev-doc-needed_bugs">Dev-doc-needed bugs</h2>
     <p><strong>Found <%=ddnBugs.bugs.length%> bugs.</strong> Learn more about <a href="https://developer.mozilla.org/en-US/docs/MDN/Contribute/Howto/Resolve_a_dev-doc-needed_bug">how to resolve a dev-doc-needed bug</a>.</p>
-    
+
     <table class="standard-table">
         <thead>
             <tr>
@@ -427,7 +427,7 @@ if (output.hasOwnProperty(obj) && typeof metrics[obj] != 'undefined' && metrics[
             </tr>
         </thead>
     <tbody>
-    
+
     <% for (var i=0; i < ddnBugs.bugs.length; i++) {
         bzLink += ddnBugs.bugs[i].id + ',';
     %>
@@ -437,19 +437,19 @@ if (output.hasOwnProperty(obj) && typeof metrics[obj] != 'undefined' && metrics[
         <td><%= ddnBugs.bugs[i].target_milestone %></td>
     </tr>
     <% } %>
-    
+
     </tbody>
     </table>
     <p>Browse as <a href="<%=bzLink%>">bug list</a>.</p>
 <% } } %>
 
-<% if (bzdr && bzdr != '') { 
+<% if (bzdr && bzdr != '') {
     if (drBugs.bugs.length > 0) {
         var bzLink = 'https://bugzilla.mozilla.org/buglist.cgi?bug_id=';
 %>
     <h2 id="Documentation_requests">Documentation requests</h2>
     <p><strong>Found <%=drBugs.bugs.length%> bugs.</strong> Documentation request bugs can contain various kinds work related to MDN pages. Read through the bug and ask questions in the bug if in doubt.</p>
-    
+
     <table class="standard-table">
         <thead>
             <tr>
@@ -458,8 +458,8 @@ if (output.hasOwnProperty(obj) && typeof metrics[obj] != 'undefined' && metrics[
             </tr>
         </thead>
     <tbody>
-    
-    <% for (var i=0; i < drBugs.bugs.length; i++) { 
+
+    <% for (var i=0; i < drBugs.bugs.length; i++) {
         bzLink += drBugs.bugs[i].id + ',';
     %>
     <tr>
@@ -467,7 +467,7 @@ if (output.hasOwnProperty(obj) && typeof metrics[obj] != 'undefined' && metrics[
         <td><%= drBugs.bugs[i].summary %></td>
     </tr>
     <% } %>
-    
+
     </tbody>
     </table>
     <p>Browse as <a href="<%=bzLink%>">bug list</a>.</p>
@@ -489,10 +489,10 @@ if (output.hasOwnProperty(obj) && typeof metrics[obj] != 'undefined' && metrics[
     </tr>
   </thead>
   <tbody>
-    <%     
+    <%
         for (var key in l10nResult) {
         if (l10nResult.hasOwnProperty(key) && typeof key != 'undefined') {
-        
+
         var translationPercent = Math.floor((l10nResult[key].metrics.translations.counter / l10nResult[key].metrics.pages.counter) * 100);
         var uptodatePercent = l10nResult[key].metrics.translations.counter == 0 ? 0 : Math.floor((l10nResult[key].metrics.updateNeeded.counter / l10nResult[key].metrics.translations.counter) * 100);
     %>

--- a/macros/DocStatusOverview.ejs
+++ b/macros/DocStatusOverview.ejs
@@ -6,10 +6,10 @@
  *  $0  (optional) Title string filter; if this is specified, pages whose title
  *      don't contain this string are ignored
  */
- 
- 
+
+
 /*** Collect doc status data ***/
-var MDN = require("MDN:Common");
+var MDN = require_macro("MDN:Common");
 var result = {};
 var totalPages = 0,
     totalNoTags = 0,
@@ -33,7 +33,7 @@ function getPages(pageList, filterString) {
                     result[pageList[aPage].title].metrics = JSON.parse(resource);
                     result[pageList[aPage].title].url = pageList[aPage].url;
                 }
-                
+
                 var subpage = getPages(pageList[aPage].subpages, filterString);
             }
         }
@@ -59,9 +59,9 @@ getPages(pageList, $0);
     </tr>
   </thead>
   <tbody>
-    <% 
+    <%
     var columns = ['noTags', 'needsTags', 'editorialReviews', 'technicalReviews', 'outdated', 'ddn', 'dr'];
-    
+
         for (var key in result) {
         totalPages += result[key].metrics.pages.counter;
         totalNeedsTags += result[key].metrics.needsTags.counter;

--- a/macros/L10nStatusOverview.ejs
+++ b/macros/L10nStatusOverview.ejs
@@ -46,7 +46,7 @@ var statusStr = mdn.localString({
 });
 
 /*** Collect doc status data ***/
-var MDN = require("MDN:Common");
+var MDN = require_macro("MDN:Common");
 var result = {};
 var totalPages = 0,
     totalTranslated = 0,
@@ -84,20 +84,20 @@ getPages(pageList);
     </tr>
   </thead>
   <tbody>
-    <%     
+    <%
         for (var key in result) {
         if (result.hasOwnProperty(key) && typeof key != 'undefined') {
             var pageCounter = result[key].metrics.pages.counter || 0;
             var translationCounter = result[key].metrics.translations.counter || 0;
             var updateCounter = result[key].metrics.updateNeeded.counter || 0;
-       
+
             totalPages += pageCounter;
             totalTranslated += translationCounter;
             totalUpToDate += updateCounter;
-        
+
             var translationPercent = Math.floor((translationCounter / pageCounter) * 100);
             var uptodatePercent = Math.floor((updateCounter / pageCounter) * 100);
-        
+
             var totalTranslatedPercent = Math.floor((totalTranslated / totalPages) * 100);
             var totalUpToDatePercent = Math.floor((totalUpToDate / totalPages) * 100);
     %>

--- a/macros/TestModules.ejs
+++ b/macros/TestModules.ejs
@@ -7,9 +7,9 @@
 
 
 function test(url) {
-    var wiki = kuma.require('DekiScript:Wiki');
+    var wiki = require_macro('DekiScript:Wiki');
     log.debug("Wiki: " + wiki);
-    wiki.template("LandingPageListSubpages", [url]);
+    template("LandingPageListSubpages", [url]);
 }
 
 %>

--- a/macros/UILocalizationStatus.ejs
+++ b/macros/UILocalizationStatus.ejs
@@ -26,7 +26,7 @@ var statusColumnTitle = mdn.localString({
 });
 
 var locale = $0;
-var MDN = require("MDN:Common");
+var MDN = require_macro("MDN:Common");
 var url = 'http://l10n.mozilla-community.org/~flod/webstatus/web_status.json';
 var mdnProjects = ["mdn", "mdn-js", "mdn-promote"];
 var result = [];
@@ -36,7 +36,7 @@ var locales = resource.locales;
 
 if (locales.hasOwnProperty(locale)) {
     var language = locales[locale];
-    
+
     for (var project in language) {
         if (language.hasOwnProperty(project) && mdnProjects.indexOf(project) >= 0) {
             result[project] = language[project];
@@ -52,13 +52,13 @@ if (locales.hasOwnProperty(locale)) {
         <th><%=statusColumnTitle%></th>
     </tr>
 
-<% 
+<%
 for (var project in result) {
     if (result.hasOwnProperty(project)) {
         var translatedPercent = Math.round(result[project].translated / result[project].total * 10000) / 100;
         var untranslatedPercent = Math.round(result[project].untranslated / result[project].total * 10000) / 100;
         var fuzzyPercent = 100 - translatedPercent - untranslatedPercent;
-%>    
+%>
 
     <tr>
         <td><%=result[project].name%></td>

--- a/macros/WebExtAPISidebar.ejs
+++ b/macros/WebExtAPISidebar.ejs
@@ -1,6 +1,6 @@
 <%
 
-var sidebarUtils = require("SidebarUtilities");
+var sidebarUtils = require_macro("SidebarUtilities");
 var output = "";
 var pageModule = page;
 var hasTag = page.hasTag;
@@ -16,7 +16,7 @@ function classifyPages(subpages) {
       events: [],
       types: []
   }
-  
+
   subpages.forEach(function(subpage) {
     if (hasTag(subpage, "Property")) {
       collection.properties.push(subpage);
@@ -41,7 +41,7 @@ function buildSidebarForSingleAPI(apiPath) {
 var subpages = pageModule.subpagesExpand(apiPath);
 
   var pageCollection = classifyPages(subpages);
-  
+
   if (pageCollection.methods.length > 0) {
     output += sidebarUtils.buildSublist(pageCollection.methods, "Methods", true);
   }
@@ -54,7 +54,7 @@ var subpages = pageModule.subpagesExpand(apiPath);
   if (pageCollection.events.length > 0) {
     output += sidebarUtils.buildSublist(pageCollection.events, "Events", true);
   }
-  
+
 output += '</ol>';
 }
 

--- a/macros/WebExtensionSidebar.ejs
+++ b/macros/WebExtensionSidebar.ejs
@@ -1,6 +1,6 @@
 <%
 
-var sidebarUtils = require("SidebarUtilities");
+var sidebarUtils = require_macro("SidebarUtilities");
 var hasTag = page.hasTag;
 var pageModule = page;
 
@@ -15,7 +15,7 @@ function classifyPages(subpages) {
       events: [],
       types: []
   }
-  
+
   subpages.forEach(function(subpage) {
     if (hasTag(subpage, "Property")) {
       collection.properties.push(subpage);
@@ -38,12 +38,12 @@ function buildSidebar(slug) {
   if (!slug) {
     return;
   }
-  
+
   var pathComponents = slug.split("/");
   if (pathComponents < 2) {
     return;
   }
-  
+
   // find out where we are in the tree
   var leafDocument = pathComponents[pathComponents.length-1];
   // 1) we are at the root
@@ -76,10 +76,10 @@ function buildSidebarForRoot(path) {
 function buildSidebarForAPI(path, parent) {
   output = '<section class="Quick_links" id="Quick_Links"><ol>';
   output += '<li><strong><a href="' +  "/en-US/docs/" + path + '"><code>' + parent + '</a></code></strong></li>';
-  
+
   var subpages = pageModule.subpagesExpand("/en-US/docs/" + path);
   var pageCollection = classifyPages(subpages);
-  
+
   if (pageCollection.methods.length > 0) {
     output += sidebarUtils.buildSublist(pageCollection.methods, "Methods");
   }

--- a/macros/bug.ejs
+++ b/macros/bug.ejs
@@ -13,7 +13,7 @@
  * https://wiki.mozilla.org/Bugzilla:REST_API
  */
 
-var mdn = require("MDN:Common");
+var mdn = require_macro("MDN:Common");
 
 var type = $1 || 'bug';
 
@@ -63,7 +63,7 @@ if ($2 != undefined && !isNaN($2)) {
     var comment = parseInt($2, 10);
     if (!isNaN(comment)) {
         bugPageURL += "#c" + comment;
-        
+
         s_comment = mdn.localString({
             "en-US":    ", comment " + comment
         });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -120,7 +120,7 @@
     },
     "brace-expansion": {
       "version": "1.1.7",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "from": "brace-expansion@>=1.1.7 <2.0.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
     },
     "buffer-shims": {
@@ -292,9 +292,9 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "coveralls": {
-      "version": "2.13.0",
+      "version": "2.13.1",
       "from": "coveralls@>=2.11.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
       "dependencies": {
         "js-yaml": {
           "version": "3.6.1",
@@ -351,9 +351,9 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-extend": {
-      "version": "0.4.1",
+      "version": "0.4.2",
       "from": "deep-extend@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
     },
     "deeper": {
       "version": "2.1.0",
@@ -506,9 +506,9 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz"
     },
     "extend": {
-      "version": "3.0.0",
-      "from": "extend@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+      "version": "3.0.1",
+      "from": "extend@3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
     },
     "extsprintf": {
       "version": "1.0.2",
@@ -596,9 +596,9 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz"
     },
     "getpass": {
-      "version": "0.1.6",
+      "version": "0.1.7",
       "from": "getpass@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -608,9 +608,9 @@
       }
     },
     "glob": {
-      "version": "7.1.1",
+      "version": "7.1.2",
       "from": "glob@>=7.0.3 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
     },
     "globby": {
       "version": "6.1.0",
@@ -709,9 +709,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "iconv-lite": {
-      "version": "0.4.15",
+      "version": "0.4.17",
       "from": "iconv-lite@>=0.4.13 <0.5.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
@@ -830,9 +830,9 @@
       "optional": true
     },
     "js-yaml": {
-      "version": "3.8.3",
+      "version": "3.8.4",
       "from": "js-yaml@>=3.3.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
@@ -963,6 +963,11 @@
       "from": "map-obj@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
+    "mdn-browser-compat-data": {
+      "version": "0.0.1",
+      "from": "mdn-browser-compat-data@>=0.0.0 <1.0.0",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.1.tgz"
+    },
     "media-typer": {
       "version": "0.3.0",
       "from": "media-typer@0.3.0",
@@ -1004,9 +1009,9 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
     },
     "minimatch": {
-      "version": "3.0.3",
-      "from": "minimatch@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+      "version": "3.0.4",
+      "from": "minimatch@>=3.0.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
     },
     "minimist": {
       "version": "1.2.0",
@@ -1190,9 +1195,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.6.3",
+      "version": "1.7.0",
       "from": "node-fetch@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.0.tgz"
     },
     "node-statsd": {
       "version": "0.1.1",
@@ -1217,9 +1222,9 @@
       }
     },
     "normalize-package-data": {
-      "version": "2.3.6",
+      "version": "2.3.8",
       "from": "normalize-package-data@>=2.3.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz"
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -2386,6 +2391,11 @@
       "from": "rewire@>=2.5.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz"
     },
+    "safe-buffer": {
+      "version": "5.0.1",
+      "from": "safe-buffer@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+    },
     "sax": {
       "version": "0.6.1",
       "from": "sax@>=0.6.0 <0.7.0",
@@ -2486,9 +2496,9 @@
       }
     },
     "stack-trace": {
-      "version": "0.0.9",
+      "version": "0.0.10",
       "from": "stack-trace@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
     },
     "stack-utils": {
       "version": "0.4.0",
@@ -2568,9 +2578,9 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
         },
         "string_decoder": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
         }
       }
     },
@@ -2592,9 +2602,9 @@
           "optional": true
         },
         "string_decoder": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "optional": true
         }
       }
@@ -2617,9 +2627,9 @@
           "optional": true
         },
         "string_decoder": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "nodeunit": "0.10.2",
     "jshint": "2.9.4",
     "ejs-lint": "0.3.0",
-    "jsonlint-cli": "1.0.1"
+    "jsonlint-cli": "1.0.1",
+    "mdn-browser-compat-data": "0.x"
   }
 }

--- a/tests/fixtures/documents/require-test-expected.txt
+++ b/tests/fixtures/documents/require-test-expected.txt
@@ -1,0 +1,4 @@
+Testing "require" of npm package:
+
+* First: Does "version" exist? yes!
+* Second: Does "data.css.properties" exist? yes!

--- a/tests/fixtures/documents/require-test.txt
+++ b/tests/fixtures/documents/require-test.txt
@@ -1,0 +1,4 @@
+Testing "require" of npm package:
+
+* First: {{ require-used("version") }}
+* Second: {{ require-used("data.css.properties") }}

--- a/tests/fixtures/macros-expected.json
+++ b/tests/fixtures/macros-expected.json
@@ -34,6 +34,9 @@
         "name": "reqlocale",
         "filename": "reqlocale.ejs"
     }, {
+        "name": "require-used",
+        "filename": "require-used.ejs"
+    }, {
         "name": "reqvar-json",
         "filename": "reqvar-json.ejs"
     }, {

--- a/tests/fixtures/templates/library1-used.ejs
+++ b/tests/fixtures/templates/library1-used.ejs
@@ -1,2 +1,2 @@
-<% var library1 = require('library1'); %>
+<% var library1 = require_macro('library1'); %>
 The result <%= library1.result($0) %>

--- a/tests/fixtures/templates/require-used.ejs
+++ b/tests/fixtures/templates/require-used.ejs
@@ -1,0 +1,13 @@
+<%
+var queryString = $0,
+    bcd = require('mdn-browser-compat-data');
+
+function getData() {
+  return queryString.split('.').reduce(function(prev, curr) {
+    return prev ? prev[curr] : undefined
+  }, bcd);
+}
+
+var output = `Does "${queryString}" exist? ${getData() ? 'yes!' : 'no!'}`;
+%>
+<%- output %>

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -100,15 +100,21 @@ module.exports = {
         next();
     },
 
-    "A template can include the output of executing another template with kumascript.template()": function (test) {
+    "A template can include the output of executing another template with template()": function (test) {
         var expected_fn = __dirname + '/fixtures/documents/template-exec-expected.txt',
             result_url  = 'http://localhost:9000/docs/template-exec';
         performTestRequest(test, expected_fn, result_url);
     },
 
-    "A template can export methods and data to another template with kumascript.require()": function (test) {
+    "A template can import methods and data from another template with require_macro()": function (test) {
         var expected_fn = __dirname + '/fixtures/documents/library-test-expected.txt',
             result_url  = 'http://localhost:9000/docs/library-test';
+        performTestRequest(test, expected_fn, result_url);
+    },
+
+    "A template can import an npm module with require()": function (test) {
+        var expected_fn = __dirname + '/fixtures/documents/require-test-expected.txt',
+            result_url  = 'http://localhost:9000/docs/require-test';
         performTestRequest(test, expected_fn, result_url);
     },
 


### PR DESCRIPTION
This PR provides the Kumascript backend machinery (including tests) that allows macro writers to ``require`` npm modules. Macro writers can use ``require`` to import any npm module included (directly or indirectly) via the dependencies listed in [``package.json``](https://github.com/escattone/kumascript/blob/use-npm-bcd-1328839/package.json#L24-L45).
- It introduces an important change that macro writers should note. The ``require`` function available within macros is now equivalent to the standard nodejs ``require``. The previous ``require`` functionality, which could only be used to load functions and data from other Kumascript macros, has been renamed to ``require_macro``. Although slightly inconvenient, I thought it better that the Kumascript-specific functionality has a Kumascript-specific name, while ``require`` keeps it's standard ``nodejs`` meaning. The macros that previously used ``require`` internally have been changed to use ``require_macro`` instead. Most of the affected macros were actually requiring the ``MDN:Common`` macro, which is not necessary since it is auto-required and available within any macro's namespace as the ``mdn`` variable, but that work was left for another PR.
- Currently, the latest release of version "0" ("0.x") of the ``mdn-browser-compat-data`` npm module is installed. It is assumed that schema changes to ``mdn-browser-compat-data`` will bump the major version, while feature/patch changes will bump the minor/patch versions.