### PR TITLE
Edits to include Android in Legacy Notice

### DIFF
--- a/macros/LegacyAddonsNotice.ejs
+++ b/macros/LegacyAddonsNotice.ejs
@@ -8,8 +8,8 @@ var output = mdn.localString({
         'If you maintain an add-on which uses the techniques described here, consider migrating it to use ' +
         'WebExtensions.</p>' +
         '<p><strong>Starting from <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 53</a>, no new legacy add-ons will be accepted on addons.mozilla.org (AMO) for desktop Firefox and Firefox for Android.</strong></p>' +
-        '<p><strong>Starting from <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 57</a>, WebExtensions will be the only supported extension type, and Firefox will not load other types. ' + 
-        'This affects desktop Firefox and Firefox for Android.</strong></p>' +
+        '<p><strong>Starting from <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 57</a>, WebExtensions will be the only supported extension type. ' +
+        'Desktop Firefox and Firefox for Android will not load other extension types. </strong></p>' + 
         '<p>Even before Firefox 57, changes coming up in the Firefox platform will break many legacy extensions. ' +
         'These changes include multiprocess Firefox (e10s), sandboxing, and multiple content processes. ' +
         'Legacy extensions that are affected by these changes should migrate to WebExtensions if they can. ' +

--- a/macros/LegacyAddonsNotice.ejs
+++ b/macros/LegacyAddonsNotice.ejs
@@ -7,12 +7,13 @@ var output = mdn.localString({
         '<a href="/en-US/Add-ons/WebExtensions">WebExtensions</a> instead. ' +
         'If you maintain an add-on which uses the techniques described here, consider migrating it to use ' +
         'WebExtensions.</p>' +
-        '<p><strong>From <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 53</a> onwards, no new legacy add-ons will be accepted on addons.mozilla.org (AMO).</strong></p>' +
-        '<p><strong>From <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 57</a> onwards, WebExtensions will be the only supported extension type, and Firefox will not load other types.</strong></p>' +
+        '<p><strong>Starting from <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 53</a>, no new legacy add-ons will be accepted on addons.mozilla.org (AMO) for desktop Firefox and Firefox for Android.</strong></p>' +
+        '<p><strong>Starting from <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 57</a>, WebExtensions will be the only supported extension type, and Firefox will not load other types. ' + 
+        'This affects desktop Firefox and Firefox for Android.</strong></p>' +
         '<p>Even before Firefox 57, changes coming up in the Firefox platform will break many legacy extensions. ' +
         'These changes include multiprocess Firefox (e10s), sandboxing, and multiple content processes. ' +
         'Legacy extensions that are affected by these changes should migrate to WebExtensions if they can. ' +
-        'See the <a href="https://blog.mozilla.org/addons/2017/02/16/the-road-to-firefox-57-compatibility-milestones/">"Compatibility Milestones" document</a> for more.</p>' +
+        'See the <a href="https://blog.mozilla.org/addons/2017/02/16/the-road-to-firefox-57-compatibility-milestones/">"Compatibility Milestones" document</a> for more information.</p>' +
         '<p>A wiki page containing <a href="https://wiki.mozilla.org/Add-ons/developer/communication">' +
         'resources, migration paths, office hours, and more</a>, '+
         'is available to help developers transition to the new technologies.</p>' +


### PR DESCRIPTION
Including Android in legacy notice and to make it more clear. Per issue #167 

