### PR TITLE
bug 924958: use mocha as new kumascript test framework

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,9 +10,9 @@ node {
         stage('Test') {
           sh 'make lint-macros'
           try {
-            sh 'make test VERSION=latest TEST_RUN_ARGS="--reporter=junit --output=junit-results"'
+            sh 'make test VERSION=latest TEST_RUN_ARGS="--reporter mocha-junit-reporter"'
           } finally {
-            junit 'junit-results/*.xml'
+            junit 'test-results.xml'
           }
         }
 
@@ -30,9 +30,9 @@ node {
         stage('Test') {
           sh 'make lint-macros'
           try {
-            sh 'make test TEST_RUN_ARGS="--reporter=junit --output=junit-results"'
+            sh 'make test TEST_RUN_ARGS="--reporter mocha-junit-reporter"'
           } finally {
-            junit 'junit-results/*.xml'
+            junit 'test-results.xml'
           }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ run:
 
 test:
 	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \
-	    /node_modules/.bin/nodeunit ${TEST_RUN_ARGS} tests
+	    /node_modules/.bin/mocha ${TEST_RUN_ARGS} tests
 
 lint:
 	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ more before you run your local development version of MDN.
 * To run the service:
     * `node run.js`
 * To run tests:
-    * `./node_modules/.bin/nodeunit tests`
+    * `./node_modules/.bin/mocha tests`
 * To check code quality:
     * `./node_modules/.bin/jshint --show-non-errors lib tests`
         * This will make a racket if it hits `parser.js`
@@ -169,6 +169,6 @@ On OS X, [kicker](https://github.com/alloy/kicker) is handy for auto-running
 tests and lint on file changes:
 
     kicker -e'./node_modules/.bin/jshint lib tests' \
-           -e'./node_modules/.bin/nodeunit tests' \
+           -e'./node_modules/.bin/mocha tests' \
            --no-growl \
            lib tests

--- a/lib/kumascript/loaders.js
+++ b/lib/kumascript/loaders.js
@@ -235,73 +235,8 @@ var FileLoader = ks_utils.Class(BaseLoader, {
 
 });
 
-// ### HTTPLoader
-//
-// Loads templates via HTTP using a template to construct an URL based on
-// template name.
-var HTTPLoader = ks_utils.Class(BaseLoader, {
-
-    default_options: {
-        // Maximum number of retry attempts
-        max_retries: 5,
-        // Time to wait between retry attempts
-        retry_wait: 100,
-        // URL template used to resolve template name to URL.
-        url_template: 'http://localhost/templates/{name}.ejs',
-        // Class used to render templates
-        template_class: ks_templates.EJSTemplate
-    },
-
-    initialize: function (options) {
-        BaseLoader.prototype.initialize.apply(this, arguments);
-        // Create a memcache instance, if necessary
-        if (this.options.memcache) {
-            var mo = this.options.memcache;
-            this.memcached = new Memcached(mo.server, mo.options || {});
-        } else {
-            // If the configuration is missing, use the fake stub cache
-            this.memcached = new ks_utils.FakeMemcached();
-        }
-        this.statsd = ks_utils.getStatsD(this.options);
-    },
-
-    // #### get(name, cb)
-    get: function (name, cb) {
-        var $this = this;
-        var tmpl_url = ks_utils.tmpl($this.options.url_template,
-                                     {name: name.toLowerCase()});
-        var req_opts = {
-            memcached: this.memcached,
-            statsd: this.statsd,
-            timeout: this.options.cache_timeout || 3600,
-            cache_control: this.options.cache_control,
-            url: tmpl_url
-        };
-
-        var retries_left = $this.options.max_retries;
-        var attempt = function () {
-            ks_caching.request(req_opts, function (err, resp, source, cache_hit) {
-                if (err || !source) {
-                    if (retries_left-- > 0) {
-                        $this.statsd.increment('loader.retries.overall');
-                        $this.statsd.increment('loader.retries.by_name.' + name);
-                        setTimeout(attempt, $this.options.retry_wait);
-                    } else {
-                        cb(err, null, false);
-                    }
-                } else {
-                    $this.compile(source, cb, cache_hit);
-                }
-            });
-        };
-        attempt();
-    }
-
-});
-
 // ### Exported public API
 module.exports = {
     BaseLoader: BaseLoader,
     FileLoader: FileLoader,
-    HTTPLoader: HTTPLoader
 };

--- a/lib/kumascript/test-utils.js
+++ b/lib/kumascript/test-utils.js
@@ -5,11 +5,15 @@
 /*jshint node: true, expr: false, boss: true */
 
 // ### Prerequisites
-var morgan = require('morgan'),
+var fs = require('fs'),
+    path = require('path'),
+    morgan = require('morgan'),
     express = require('express'),
+    request = require('request'),
     ks_utils = require(__dirname + '/utils'),
     ks_loaders = require(__dirname + '/loaders'),
-    ks_templates = require(__dirname + '/templates');
+    ks_templates = require(__dirname + '/templates'),
+    FIXTURES_PATH = path.join(__dirname, '..', '..', 'tests', 'fixtures');
 
 var DEBUG = false;
 
@@ -30,23 +34,6 @@ var JSONifyLoader = ks_utils.Class(ks_loaders.BaseLoader, {
     },
     compile: function (name, cb) {
         cb(null, new JSONifyTemplate({name: name}));
-    }
-});
-
-// Loader which pulls from a pre-defined object full of named templates.
-var LocalLoader = ks_utils.Class(ks_loaders.BaseLoader, {
-    default_options: {
-        templates: { }
-    },
-    load: function (name, cb) {
-        if (name in this.options.templates) {
-            cb(null, this.options.templates[name]);
-        } else {
-            cb("not found", null);
-        }
-    },
-    compile: function (source, cb) {
-        cb(null, source);
     }
 });
 
@@ -97,7 +84,7 @@ function createTestServer (port) {
         // Force a delay, which tickles async bugs in need of fixes
         setTimeout(mw_next, 50);
     });
-    app.use(express.static(__dirname + '/../../tests/fixtures'));
+    app.use(express.static(FIXTURES_PATH));
 
     var server = app.listen(port || 9001);
 
@@ -108,13 +95,43 @@ function createTestServer (port) {
     return app;
 }
 
+function readTestFixture(relpath, done, callback) {
+    var fullpath = path.join(FIXTURES_PATH, relpath);
+    fs.readFile(fullpath, 'utf8', function (err, data) {
+        if (err) {
+            done(err);
+        } else {
+            callback(data);
+        }
+    });
+}
+
+function testRequest(req_options, done, callback) {
+    request(req_options, function (err, resp, result) {
+        if (!err) {
+            callback(resp, result);
+        }
+        done(err);
+    });
+}
+
+function testRequestExpected(req_options, expected_relpath, done, callback) {
+    readTestFixture(expected_relpath, done, function(expected) {
+        testRequest(req_options, done, function (resp, result) {
+            callback(resp, result, expected);
+        });
+    })
+}
+
 // ### Exported public API
 module.exports = {
     JSONifyTemplate: JSONifyTemplate,
     JSONifyLoader: JSONifyLoader,
-    LocalLoader: LocalLoader,
     LocalClassLoader: LocalClassLoader,
     BrokenCompilationTemplate: BrokenCompilationTemplate,
     BrokenExecutionTemplate: BrokenExecutionTemplate,
-    createTestServer: createTestServer
+    createTestServer: createTestServer,
+    readTestFixture: readTestFixture,
+    testRequest: testRequest,
+    testRequestExpected: testRequestExpected
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,11 +7,6 @@
       "from": "accepts@>=1.3.3 <1.4.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
     },
-    "acorn": {
-      "version": "4.0.11",
-      "from": "acorn@>=4.0.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
-    },
     "addressparser": {
       "version": "0.1.3",
       "from": "addressparser@>=0.1.3 <0.2.0",
@@ -23,19 +18,9 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
     },
     "ansi-styles": {
-      "version": "1.0.0",
-      "from": "ansi-styles@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-    },
-    "argparse": {
-      "version": "1.0.9",
-      "from": "argparse@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "from": "array-find-index@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+      "version": "2.2.1",
+      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -46,21 +31,6 @@
       "version": "0.0.1",
       "from": "array-indexofobject@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/array-indexofobject/-/array-indexofobject-0.0.1.tgz"
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "from": "array-union@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "from": "array-uniq@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "asn1": {
       "version": "0.2.3",
@@ -92,11 +62,6 @@
       "from": "aws4@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
     },
-    "balanced-match": {
-      "version": "0.4.2",
-      "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-    },
     "basic-auth": {
       "version": "1.0.4",
       "from": "basic-auth@>=1.0.3 <1.1.0",
@@ -108,128 +73,35 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "optional": true
     },
-    "bluebird": {
-      "version": "3.5.0",
-      "from": "bluebird@>=3.3.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
-    },
     "boom": {
       "version": "2.10.1",
       "from": "boom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
-    "brace-expansion": {
-      "version": "1.1.7",
-      "from": "brace-expansion@>=1.1.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-    },
     "camelcase": {
-      "version": "3.0.0",
-      "from": "camelcase@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-    },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "from": "camelcase-keys@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "from": "camelcase@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
-        }
-      }
+      "version": "2.1.1",
+      "from": "camelcase@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
     },
     "caseless": {
       "version": "0.11.0",
       "from": "caseless@>=0.11.0 <0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
     },
-    "caw": {
-      "version": "1.2.0",
-      "from": "caw@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
-      "dependencies": {
-        "object-assign": {
-          "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-        }
-      }
-    },
     "chalk": {
-      "version": "0.4.0",
-      "from": "chalk@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-      "dependencies": {
-        "strip-ansi": {
-          "version": "0.1.1",
-          "from": "strip-ansi@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
-        }
-      }
-    },
-    "clean-yaml-object": {
-      "version": "0.1.0",
-      "from": "clean-yaml-object@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz"
-    },
-    "cli": {
-      "version": "1.0.1",
-      "from": "cli@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz"
-    },
-    "cli-fs": {
-      "version": "1.0.4",
-      "from": "cli-fs@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-fs/-/cli-fs-1.0.4.tgz"
-    },
-    "cli-rc": {
-      "version": "1.0.12",
-      "from": "cli-rc@1.0.12",
-      "resolved": "https://registry.npmjs.org/cli-rc/-/cli-rc-1.0.12.tgz",
-      "dependencies": {
-        "async": {
-          "version": "1.4.2",
-          "from": "async@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
-        }
-      }
-    },
-    "cli-regexp": {
-      "version": "0.1.2",
-      "from": "cli-regexp@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/cli-regexp/-/cli-regexp-0.1.2.tgz"
-    },
-    "cli-util": {
-      "version": "1.1.27",
-      "from": "cli-util@>=1.1.27 <1.2.0",
-      "resolved": "https://registry.npmjs.org/cli-util/-/cli-util-1.1.27.tgz"
+      "version": "1.1.3",
+      "from": "chalk@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "cliui": {
       "version": "3.2.0",
-      "from": "cliui@>=3.2.0 <4.0.0",
+      "from": "cliui@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
     },
     "code-point-at": {
       "version": "1.1.0",
       "from": "code-point-at@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-    },
-    "color-support": {
-      "version": "1.1.2",
-      "from": "color-support@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.2.tgz"
     },
     "colors": {
       "version": "1.0.3",
@@ -246,20 +118,10 @@
       "from": "commander@>=2.9.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
-    "concat-map": {
-      "version": "0.0.1",
-      "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-    },
     "connection-parse": {
       "version": "0.0.7",
       "from": "connection-parse@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz"
-    },
-    "console-browserify": {
-      "version": "1.1.0",
-      "from": "console-browserify@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
     },
     "content-disposition": {
       "version": "0.5.1",
@@ -281,42 +143,15 @@
       "from": "cookie-signature@1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
     },
-    "core-js": {
-      "version": "2.1.5",
-      "from": "core-js@2.1.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.1.5.tgz"
-    },
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
-    "coveralls": {
-      "version": "2.13.1",
-      "from": "coveralls@>=2.11.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.6.1",
-          "from": "js-yaml@3.6.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz"
-        }
-      }
-    },
-    "cross-spawn": {
-      "version": "4.0.2",
-      "from": "cross-spawn@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz"
-    },
     "cryptiles": {
       "version": "2.0.5",
       "from": "cryptiles@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "from": "currently-unhandled@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
     "cycle": {
       "version": "1.0.3",
@@ -335,11 +170,6 @@
         }
       }
     },
-    "date-now": {
-      "version": "0.1.4",
-      "from": "date-now@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-    },
     "debug": {
       "version": "2.2.0",
       "from": "debug@>=2.2.0 <2.3.0",
@@ -350,25 +180,10 @@
       "from": "decamelize@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
-    "deep-extend": {
-      "version": "0.4.2",
-      "from": "deep-extend@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
-    },
-    "deeper": {
-      "version": "2.1.0",
-      "from": "deeper@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz"
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "from": "delayed-stream@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-    },
-    "denodeify": {
-      "version": "1.2.1",
-      "from": "denodeify@1.2.1",
-      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz"
     },
     "depd": {
       "version": "1.1.0",
@@ -379,43 +194,6 @@
       "version": "1.0.4",
       "from": "destroy@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
-    },
-    "diff": {
-      "version": "1.4.0",
-      "from": "diff@>=1.3.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
-    },
-    "dom-serializer": {
-      "version": "0.1.0",
-      "from": "dom-serializer@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "from": "domelementtype@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-        },
-        "entities": {
-          "version": "1.1.1",
-          "from": "entities@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-        }
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.0",
-      "from": "domelementtype@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-    },
-    "domhandler": {
-      "version": "2.3.0",
-      "from": "domhandler@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-    },
-    "domutils": {
-      "version": "1.5.1",
-      "from": "domutils@>=1.5.0 <1.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -433,42 +211,10 @@
       "from": "ejs@2.5.2",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.2.tgz"
     },
-    "ejs-include-regex": {
-      "version": "1.0.0",
-      "from": "ejs-include-regex@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ejs-include-regex/-/ejs-include-regex-1.0.0.tgz"
-    },
-    "ejs-lint": {
-      "version": "0.3.0",
-      "from": "ejs-lint@0.3.0",
-      "resolved": "https://registry.npmjs.org/ejs-lint/-/ejs-lint-0.3.0.tgz",
-      "dependencies": {
-        "ejs": {
-          "version": "2.5.6",
-          "from": "ejs@2.5.6",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz"
-        }
-      }
-    },
     "encodeurl": {
       "version": "1.0.1",
       "from": "encodeurl@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "from": "encoding@>=0.1.11 <0.2.0",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
-    },
-    "entities": {
-      "version": "1.0.0",
-      "from": "entities@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-    },
-    "error-ex": {
-      "version": "1.3.1",
-      "from": "error-ex@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
     },
     "escape-html": {
       "version": "1.0.3",
@@ -480,25 +226,10 @@
       "from": "escape-string-regexp@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
-    "esprima": {
-      "version": "2.7.3",
-      "from": "esprima@>=2.6.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
-    },
     "etag": {
       "version": "1.7.0",
       "from": "etag@>=1.7.0 <1.8.0",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
-    },
-    "events-to-array": {
-      "version": "1.1.2",
-      "from": "events-to-array@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz"
-    },
-    "exit": {
-      "version": "0.1.2",
-      "from": "exit@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
     },
     "express": {
       "version": "4.14.0",
@@ -507,7 +238,7 @@
     },
     "extend": {
       "version": "3.0.1",
-      "from": "extend@3.0.1",
+      "from": "extend@>=3.0.0 <3.1.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
     },
     "extsprintf": {
@@ -535,16 +266,6 @@
       "from": "finalhandler@0.5.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz"
     },
-    "find-up": {
-      "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-    },
-    "foreground-child": {
-      "version": "1.5.6",
-      "from": "foreground-child@>=1.3.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz"
-    },
     "forever-agent": {
       "version": "0.6.1",
       "from": "forever-agent@>=0.6.1 <0.7.0",
@@ -565,11 +286,6 @@
       "from": "fresh@0.3.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
     },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-    },
     "generate-function": {
       "version": "2.0.0",
       "from": "generate-function@>=2.0.0 <3.0.0",
@@ -579,21 +295,6 @@
       "version": "1.2.0",
       "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-    },
-    "get-caller-file": {
-      "version": "1.0.2",
-      "from": "get-caller-file@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
-    },
-    "get-proxy": {
-      "version": "1.1.0",
-      "from": "get-proxy@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz"
-    },
-    "get-stdin": {
-      "version": "5.0.1",
-      "from": "get-stdin@5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz"
     },
     "getpass": {
       "version": "0.1.7",
@@ -607,21 +308,6 @@
         }
       }
     },
-    "glob": {
-      "version": "7.1.2",
-      "from": "glob@>=7.0.3 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-    },
-    "globby": {
-      "version": "6.1.0",
-      "from": "globby@>=6.1.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz"
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "from": "graceful-fs@>=4.1.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-    },
     "graceful-readlink": {
       "version": "1.0.1",
       "from": "graceful-readlink@>=1.0.0",
@@ -630,29 +316,12 @@
     "har-validator": {
       "version": "2.0.6",
       "from": "har-validator@>=2.0.6 <2.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
       "from": "has-ansi@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "from": "has-color@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
     },
     "hashring": {
       "version": "3.2.0",
@@ -681,23 +350,6 @@
       "from": "hoek@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
-    "hosted-git-info": {
-      "version": "2.4.2",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz"
-    },
-    "htmlparser2": {
-      "version": "3.8.3",
-      "from": "htmlparser2@>=3.8.0 <3.9.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
-        }
-      }
-    },
     "http-errors": {
       "version": "1.5.1",
       "from": "http-errors@>=1.5.0 <1.6.0",
@@ -708,29 +360,14 @@
       "from": "http-signature@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
-    "iconv-lite": {
-      "version": "0.4.17",
-      "from": "iconv-lite@>=0.4.13 <0.5.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz"
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "from": "indent-string@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-    },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
+      "from": "inherits@2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@>=1.3.4 <1.4.0",
+      "from": "ini@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "invert-kv": {
@@ -743,21 +380,6 @@
       "from": "ipaddr.js@1.3.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "from": "is-finite@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
@@ -768,45 +390,20 @@
       "from": "is-my-json-valid@>=2.12.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz"
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "from": "is-obj@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
-    },
     "is-property": {
       "version": "1.0.2",
       "from": "is-property@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-    },
     "isarray": {
       "version": "0.0.1",
       "from": "isarray@0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-    },
-    "isexe": {
-      "version": "1.1.2",
-      "from": "isexe@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "from": "isomorphic-fetch@2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
     },
     "isstream": {
       "version": "0.1.2",
@@ -818,46 +415,17 @@
       "from": "jackpot@>=0.0.6",
       "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz"
     },
-    "jjv": {
-      "version": "1.0.2",
-      "from": "jjv@1.0.2",
-      "resolved": "https://registry.npmjs.org/jjv/-/jjv-1.0.2.tgz"
-    },
     "jodid25519": {
       "version": "1.0.2",
       "from": "jodid25519@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "optional": true
     },
-    "js-yaml": {
-      "version": "3.8.4",
-      "from": "js-yaml@>=3.3.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "from": "esprima@>=3.1.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
-        }
-      }
-    },
     "jsbn": {
       "version": "0.1.1",
       "from": "jsbn@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "optional": true
-    },
-    "jshint": {
-      "version": "2.9.4",
-      "from": "jshint@2.9.4",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "3.7.0",
-          "from": "lodash@>=3.7.0 <3.8.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
-        }
-      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -868,38 +436,6 @@
       "version": "5.0.1",
       "from": "json-stringify-safe@>=5.0.1 <5.1.0",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-    },
-    "jsonlint": {
-      "version": "1.6.2",
-      "from": "jsonlint@1.6.2",
-      "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.2.tgz"
-    },
-    "jsonlint-cli": {
-      "version": "1.0.1",
-      "from": "jsonlint-cli@1.0.1",
-      "resolved": "https://registry.npmjs.org/jsonlint-cli/-/jsonlint-cli-1.0.1.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "from": "glob@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
-        },
-        "globby": {
-          "version": "4.0.0",
-          "from": "globby@4.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz"
-        },
-        "lodash": {
-          "version": "4.6.1",
-          "from": "lodash@4.6.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz"
-        },
-        "minimatch": {
-          "version": "3.0.0",
-          "from": "minimatch@3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-        }
-      }
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -918,55 +454,15 @@
         }
       }
     },
-    "JSV": {
-      "version": "4.0.2",
-      "from": "JSV@>=4.0.0",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
-    },
     "lcid": {
       "version": "1.0.0",
       "from": "lcid@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
-    "lcov-parse": {
-      "version": "0.0.10",
-      "from": "lcov-parse@0.0.10",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz"
-    },
-    "load-json-file": {
-      "version": "1.1.0",
-      "from": "load-json-file@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
-    },
     "lodash": {
       "version": "4.17.4",
       "from": "lodash@>=4.14.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-    },
-    "log-driver": {
-      "version": "1.2.5",
-      "from": "log-driver@1.2.5",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz"
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
-    },
-    "lru-cache": {
-      "version": "4.0.2",
-      "from": "lru-cache@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz"
-    },
-    "map-obj": {
-      "version": "1.0.1",
-      "from": "map-obj@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-    },
-    "mdn-browser-compat-data": {
-      "version": "0.0.1",
-      "from": "mdn-browser-compat-data@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.1.tgz"
     },
     "media-typer": {
       "version": "0.3.0",
@@ -977,11 +473,6 @@
       "version": "2.2.2",
       "from": "memcached@2.2.2",
       "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz"
-    },
-    "meow": {
-      "version": "3.7.0",
-      "from": "meow@3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -1008,28 +499,6 @@
       "from": "mime-types@>=2.1.11 <2.2.0",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
     },
-    "minimatch": {
-      "version": "3.0.4",
-      "from": "minimatch@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "from": "minimist@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "from": "mkdirp@0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        }
-      }
-    },
     "morgan": {
       "version": "1.7.0",
       "from": "morgan@1.7.0",
@@ -1049,16 +518,6 @@
           "version": "1.5.2",
           "from": "async@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "from": "camelcase@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "from": "yargs@>=3.19.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
         }
       }
     },
@@ -1194,1013 +653,20 @@
         }
       }
     },
-    "node-fetch": {
-      "version": "1.7.0",
-      "from": "node-fetch@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.0.tgz"
-    },
     "node-statsd": {
       "version": "0.1.1",
       "from": "node-statsd@0.1.1",
       "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz"
-    },
-    "nodeunit": {
-      "version": "0.10.2",
-      "from": "nodeunit@0.10.2",
-      "resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.10.2.tgz"
-    },
-    "nomnom": {
-      "version": "1.8.1",
-      "from": "nomnom@>=1.5.0",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "from": "underscore@>=1.6.0 <1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-        }
-      }
-    },
-    "normalize-package-data": {
-      "version": "2.3.8",
-      "from": "normalize-package-data@>=2.3.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz"
     },
     "number-is-nan": {
       "version": "1.0.1",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
     },
-    "nyc": {
-      "version": "7.1.0",
-      "from": "nyc@>=7.1.0 <8.0.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-7.1.0.tgz",
-      "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "from": "align-text@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-        },
-        "amdefine": {
-          "version": "1.0.0",
-          "from": "amdefine@>=0.0.4",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-        },
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-        },
-        "append-transform": {
-          "version": "0.3.0",
-          "from": "append-transform@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz"
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "from": "arr-diff@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
-        },
-        "arr-flatten": {
-          "version": "1.0.1",
-          "from": "arr-flatten@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "from": "array-unique@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "from": "arrify@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-        },
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.4.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "babel-code-frame": {
-          "version": "6.11.0",
-          "from": "babel-code-frame@>=6.8.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz"
-        },
-        "babel-generator": {
-          "version": "6.11.4",
-          "from": "babel-generator@>=6.11.3 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.11.4.tgz"
-        },
-        "babel-messages": {
-          "version": "6.8.0",
-          "from": "babel-messages@>=6.8.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-        },
-        "babel-runtime": {
-          "version": "6.9.2",
-          "from": "babel-runtime@>=6.9.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
-        },
-        "babel-template": {
-          "version": "6.9.0",
-          "from": "babel-template@>=6.9.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz"
-        },
-        "babel-traverse": {
-          "version": "6.11.4",
-          "from": "babel-traverse@>=6.9.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.11.4.tgz"
-        },
-        "babel-types": {
-          "version": "6.11.1",
-          "from": "babel-types@>=6.10.2 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.11.1.tgz"
-        },
-        "babylon": {
-          "version": "6.8.4",
-          "from": "babylon@>=6.8.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz"
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "from": "balanced-match@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-        },
-        "brace-expansion": {
-          "version": "1.1.6",
-          "from": "brace-expansion@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-        },
-        "braces": {
-          "version": "1.8.5",
-          "from": "braces@>=1.8.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "from": "builtin-modules@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-        },
-        "caching-transform": {
-          "version": "1.0.1",
-          "from": "caching-transform@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz"
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "from": "center-align@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "optional": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "from": "cliui@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "optional": true,
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "optional": true
-            }
-          }
-        },
-        "code-point-at": {
-          "version": "1.0.0",
-          "from": "code-point-at@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "from": "commondir@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "from": "concat-map@0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-        },
-        "convert-source-map": {
-          "version": "1.3.0",
-          "from": "convert-source-map@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
-        },
-        "core-js": {
-          "version": "2.4.1",
-          "from": "core-js@>=2.4.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-        },
-        "cross-spawn": {
-          "version": "4.0.0",
-          "from": "cross-spawn@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "from": "decamelize@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-        },
-        "default-require-extensions": {
-          "version": "1.0.0",
-          "from": "default-require-extensions@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "from": "detect-indent@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-            }
-          }
-        },
-        "error-ex": {
-          "version": "1.3.0",
-          "from": "error-ex@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "from": "esutils@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "from": "expand-brackets@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "from": "expand-range@>=1.8.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "from": "extglob@>=0.3.1 <0.4.0",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-        },
-        "filename-regex": {
-          "version": "2.0.0",
-          "from": "filename-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "from": "fill-range@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
-        },
-        "find-cache-dir": {
-          "version": "0.1.1",
-          "from": "find-cache-dir@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz"
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "from": "find-up@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-        },
-        "for-in": {
-          "version": "0.1.5",
-          "from": "for-in@>=0.1.5 <0.2.0",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
-        },
-        "for-own": {
-          "version": "0.1.4",
-          "from": "for-own@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
-        },
-        "foreground-child": {
-          "version": "1.5.3",
-          "from": "foreground-child@>=1.5.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.3.tgz"
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "from": "fs.realpath@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-        },
-        "get-caller-file": {
-          "version": "1.0.1",
-          "from": "get-caller-file@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.1.tgz"
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-        },
-        "glob": {
-          "version": "7.0.5",
-          "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "from": "glob-base@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "from": "glob-parent@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-        },
-        "globals": {
-          "version": "8.18.0",
-          "from": "globals@>=8.3.0 <9.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-        },
-        "graceful-fs": {
-          "version": "4.1.4",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
-        },
-        "handlebars": {
-          "version": "4.0.5",
-          "from": "handlebars@>=4.0.3 <5.0.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "from": "source-map@>=0.4.4 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-            }
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "from": "has-flag@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-        },
-        "hosted-git-info": {
-          "version": "2.1.5",
-          "from": "hosted-git-info@>=2.1.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "from": "imurmurhash@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-        },
-        "inflight": {
-          "version": "1.0.5",
-          "from": "inflight@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-        },
-        "invariant": {
-          "version": "2.2.1",
-          "from": "invariant@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "from": "invert-kv@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "from": "is-arrayish@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-        },
-        "is-buffer": {
-          "version": "1.1.3",
-          "from": "is-buffer@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "from": "is-builtin-module@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-        },
-        "is-dotfile": {
-          "version": "1.0.2",
-          "from": "is-dotfile@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "from": "is-equal-shallow@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "from": "is-extendable@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "from": "is-extglob@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-        },
-        "is-finite": {
-          "version": "1.0.1",
-          "from": "is-finite@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "from": "is-glob@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "from": "is-number@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "from": "is-primitive@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "from": "is-utf8@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "isexe": {
-          "version": "1.1.2",
-          "from": "isexe@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
-        },
-        "istanbul-lib-coverage": {
-          "version": "1.0.0-alpha.4",
-          "from": "istanbul-lib-coverage@>=1.0.0-alpha.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0-alpha.4.tgz"
-        },
-        "istanbul-lib-hook": {
-          "version": "1.0.0-alpha.4",
-          "from": "istanbul-lib-hook@>=1.0.0-alpha.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.4.tgz"
-        },
-        "istanbul-lib-instrument": {
-          "version": "1.1.0-alpha.4",
-          "from": "istanbul-lib-instrument@>=1.1.0-alpha.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.0-alpha.4.tgz"
-        },
-        "istanbul-lib-report": {
-          "version": "1.0.0-alpha.3",
-          "from": "istanbul-lib-report@>=1.0.0-alpha.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
-          "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
-            }
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "1.0.0-alpha.10",
-          "from": "istanbul-lib-source-maps@>=1.0.0-alpha.10 <2.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.0-alpha.10.tgz"
-        },
-        "istanbul-reports": {
-          "version": "1.0.0-alpha.8",
-          "from": "istanbul-reports@>=1.0.0-alpha.8 <2.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0-alpha.8.tgz"
-        },
-        "js-tokens": {
-          "version": "2.0.0",
-          "from": "js-tokens@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-        },
-        "kind-of": {
-          "version": "3.0.3",
-          "from": "kind-of@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz"
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "from": "lazy-cache@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "from": "lcid@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "from": "load-json-file@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
-        },
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
-        },
-        "lodash.assign": {
-          "version": "4.0.9",
-          "from": "lodash.assign@>=4.0.9 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz"
-        },
-        "lodash.keys": {
-          "version": "4.0.7",
-          "from": "lodash.keys@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
-        },
-        "lodash.rest": {
-          "version": "4.0.3",
-          "from": "lodash.rest@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz"
-        },
-        "longest": {
-          "version": "1.0.1",
-          "from": "longest@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-        },
-        "loose-envify": {
-          "version": "1.2.0",
-          "from": "loose-envify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-          "dependencies": {
-            "js-tokens": {
-              "version": "1.0.3",
-              "from": "js-tokens@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
-            }
-          }
-        },
-        "lru-cache": {
-          "version": "4.0.1",
-          "from": "lru-cache@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
-        },
-        "md5-hex": {
-          "version": "1.3.0",
-          "from": "md5-hex@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz"
-        },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "from": "md5-o-matic@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "from": "micromatch@>=2.3.11 <3.0.0",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
-        },
-        "minimatch": {
-          "version": "3.0.2",
-          "from": "minimatch@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        },
-        "normalize-package-data": {
-          "version": "2.3.5",
-          "from": "normalize-package-data@>=2.3.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
-        },
-        "normalize-path": {
-          "version": "2.0.1",
-          "from": "normalize-path@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
-        },
-        "number-is-nan": {
-          "version": "1.0.0",
-          "from": "number-is-nan@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-        },
-        "object.omit": {
-          "version": "2.0.0",
-          "from": "object.omit@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
-        },
-        "once": {
-          "version": "1.3.3",
-          "from": "once@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
-        },
-        "os-homedir": {
-          "version": "1.0.1",
-          "from": "os-homedir@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "from": "os-locale@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "from": "parse-glob@>=3.0.4 <4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "from": "parse-json@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "from": "path-exists@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "from": "path-parse@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "from": "path-type@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-        },
-        "pify": {
-          "version": "2.3.0",
-          "from": "pify@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "from": "pinkie@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "from": "pkg-dir@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
-        },
-        "pkg-up": {
-          "version": "1.0.0",
-          "from": "pkg-up@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz"
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "from": "preserve@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "from": "pseudomap@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
-        },
-        "randomatic": {
-          "version": "1.1.5",
-          "from": "randomatic@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "from": "read-pkg@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "from": "read-pkg-up@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
-        },
-        "regenerator-runtime": {
-          "version": "0.9.5",
-          "from": "regenerator-runtime@>=0.9.5 <0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
-        },
-        "regex-cache": {
-          "version": "0.4.3",
-          "from": "regex-cache@>=0.4.2 <0.5.0",
-          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "from": "repeat-element@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-        },
-        "repeat-string": {
-          "version": "1.5.4",
-          "from": "repeat-string@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "from": "repeating@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "from": "require-directory@>=2.1.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "from": "require-main-filename@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-        },
-        "resolve-from": {
-          "version": "2.0.0",
-          "from": "resolve-from@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "from": "right-align@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "optional": true
-        },
-        "rimraf": {
-          "version": "2.5.4",
-          "from": "rimraf@>=2.5.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-        },
-        "semver": {
-          "version": "5.3.0",
-          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "from": "set-blocking@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-        },
-        "signal-exit": {
-          "version": "3.0.0",
-          "from": "signal-exit@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
-        },
-        "slide": {
-          "version": "1.1.6",
-          "from": "slide@>=1.1.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-        },
-        "spawn-wrap": {
-          "version": "1.2.4",
-          "from": "spawn-wrap@>=1.2.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
-          "dependencies": {
-            "signal-exit": {
-              "version": "2.1.2",
-              "from": "signal-exit@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-            }
-          }
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "from": "spdx-correct@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
-        },
-        "spdx-exceptions": {
-          "version": "1.0.5",
-          "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz"
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.2",
-          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
-        },
-        "spdx-license-ids": {
-          "version": "1.2.1",
-          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
-        },
-        "string-width": {
-          "version": "1.0.1",
-          "from": "string-width@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "from": "strip-bom@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-        },
-        "test-exclude": {
-          "version": "1.1.0",
-          "from": "test-exclude@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-1.1.0.tgz"
-        },
-        "to-fast-properties": {
-          "version": "1.0.2",
-          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-        },
-        "uglify-js": {
-          "version": "2.7.0",
-          "from": "uglify-js@>=2.6.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
-          "optional": true,
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "optional": true
-            },
-            "yargs": {
-              "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "optional": true
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "optional": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-        },
-        "which": {
-          "version": "1.2.10",
-          "from": "which@>=1.2.9 <2.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "from": "which-module@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "from": "wordwrap@>=0.0.2 <0.1.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-        },
-        "wrap-ansi": {
-          "version": "2.0.0",
-          "from": "wrap-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "from": "wrappy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-        },
-        "write-file-atomic": {
-          "version": "1.1.4",
-          "from": "write-file-atomic@>=1.1.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz"
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "from": "y18n@>=3.2.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
-        },
-        "yallist": {
-          "version": "2.0.0",
-          "from": "yallist@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
-        },
-        "yargs": {
-          "version": "4.8.1",
-          "from": "yargs@>=4.8.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-          "dependencies": {
-            "cliui": {
-              "version": "3.2.0",
-              "from": "cliui@>=3.2.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
-            },
-            "window-size": {
-              "version": "0.2.0",
-              "from": "window-size@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "2.4.1",
-          "from": "yargs-parser@>=2.4.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "from": "camelcase@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
     "oauth-sign": {
       "version": "0.8.2",
       "from": "oauth-sign@>=0.8.1 <0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "from": "object-assign@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-    },
-    "omni-fetch": {
-      "version": "0.1.0",
-      "from": "omni-fetch@0.1.0",
-      "resolved": "https://registry.npmjs.org/omni-fetch/-/omni-fetch-0.1.0.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2212,70 +678,25 @@
       "from": "on-headers@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
     },
-    "once": {
-      "version": "1.4.0",
-      "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-    },
-    "only-shallow": {
-      "version": "1.2.0",
-      "from": "only-shallow@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz"
-    },
-    "opener": {
-      "version": "1.4.3",
-      "from": "opener@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz"
-    },
-    "os-homedir": {
-      "version": "1.0.1",
-      "from": "os-homedir@1.0.1",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-    },
     "os-locale": {
       "version": "1.4.0",
       "from": "os-locale@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parseurl": {
       "version": "1.3.1",
       "from": "parseurl@>=1.3.1 <1.4.0",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
     },
-    "path-exists": {
-      "version": "2.1.0",
-      "from": "path-exists@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-    },
     "path-to-regexp": {
       "version": "0.1.7",
       "from": "path-to-regexp@0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
     },
-    "path-type": {
-      "version": "1.1.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-    },
     "pegjs": {
       "version": "0.7.0",
       "from": "pegjs@0.7.0",
       "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.7.0.tgz"
-    },
-    "pify": {
-      "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
@@ -2287,20 +708,10 @@
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-    },
     "proxy-addr": {
       "version": "1.1.4",
       "from": "proxy-addr@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz"
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "from": "pseudomap@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
     },
     "punycode": {
       "version": "1.4.1",
@@ -2317,47 +728,10 @@
       "from": "range-parser@>=1.2.0 <1.3.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
     },
-    "rc": {
-      "version": "1.2.1",
-      "from": "rc@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "from": "strip-json-comments@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-        }
-      }
-    },
-    "read-input": {
-      "version": "0.3.1",
-      "from": "read-input@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/read-input/-/read-input-0.3.1.tgz"
-    },
-    "read-pkg": {
-      "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
-    },
     "readable-stream": {
       "version": "1.0.34",
       "from": "readable-stream@>=1.0.17 <1.1.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-    },
-    "redent": {
-      "version": "1.0.0",
-      "from": "redent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "from": "repeating@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
     },
     "request": {
       "version": "2.79.0",
@@ -2371,30 +745,10 @@
         }
       }
     },
-    "require-directory": {
-      "version": "2.1.1",
-      "from": "require-directory@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "from": "require-main-filename@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-    },
     "retry": {
       "version": "0.6.0",
       "from": "retry@0.6.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
-    },
-    "rewire": {
-      "version": "2.5.2",
-      "from": "rewire@>=2.5.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz"
-    },
-    "safe-buffer": {
-      "version": "5.0.1",
-      "from": "safe-buffer@>=5.0.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
     },
     "sax": {
       "version": "0.6.1",
@@ -2405,11 +759,6 @@
       "version": "1.0.0",
       "from": "secure-keys@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz"
-    },
-    "semver": {
-      "version": "5.3.0",
-      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
     },
     "send": {
       "version": "0.14.1",
@@ -2433,25 +782,10 @@
         }
       }
     },
-    "set-blocking": {
-      "version": "2.0.0",
-      "from": "set-blocking@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-    },
     "setprototypeof": {
       "version": "1.0.2",
       "from": "setprototypeof@1.0.2",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
-    },
-    "shelljs": {
-      "version": "0.3.0",
-      "from": "shelljs@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
     },
     "simple-lru-cache": {
       "version": "0.0.2",
@@ -2462,26 +796,6 @@
       "version": "1.0.9",
       "from": "sntp@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-    },
-    "spdx-correct": {
-      "version": "1.0.2",
-      "from": "spdx-correct@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
-    },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-    },
-    "spdx-license-ids": {
-      "version": "1.2.2",
-      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
       "version": "1.13.0",
@@ -2500,11 +814,6 @@
       "from": "stack-trace@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
     },
-    "stack-utils": {
-      "version": "0.4.0",
-      "from": "stack-utils@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-0.4.0.tgz"
-    },
     "statuses": {
       "version": "1.3.1",
       "from": "statuses@>=1.3.0 <1.4.0",
@@ -2517,7 +826,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "from": "string-width@>=1.0.2 <2.0.0",
+      "from": "string-width@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
     },
     "stringstream": {
@@ -2530,128 +839,19 @@
       "from": "strip-ansi@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "from": "strip-bom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "from": "strip-indent@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "dependencies": {
-        "get-stdin": {
-          "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-        }
-      }
-    },
-    "strip-json-comments": {
-      "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-    },
     "supports-color": {
       "version": "2.0.0",
       "from": "supports-color@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-    },
-    "syntax-error": {
-      "version": "1.3.0",
-      "from": "syntax-error@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz"
-    },
-    "tap": {
-      "version": "7.1.2",
-      "from": "tap@>=7.0.0 <8.0.0",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-7.1.2.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
-        }
-      }
-    },
-    "tap-mocha-reporter": {
-      "version": "2.0.1",
-      "from": "tap-mocha-reporter@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-2.0.1.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "optional": true
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "from": "readable-stream@>=2.1.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "optional": true
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "optional": true
-        }
-      }
-    },
-    "tap-parser": {
-      "version": "2.2.3",
-      "from": "tap-parser@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-2.2.3.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "optional": true
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "optional": true
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "optional": true
-        }
-      }
-    },
-    "tmatch": {
-      "version": "2.0.1",
-      "from": "tmatch@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz"
     },
     "tough-cookie": {
       "version": "2.3.2",
       "from": "tough-cookie@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
     },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "from": "trim-newlines@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-    },
     "tunnel-agent": {
       "version": "0.4.3",
-      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tweetnacl": {
@@ -2670,20 +870,10 @@
       "from": "underscore@1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
-    "unicode-length": {
-      "version": "1.0.3",
-      "from": "unicode-length@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz"
-    },
     "unpipe": {
       "version": "1.0.0",
       "from": "unpipe@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
       "version": "1.0.0",
@@ -2695,11 +885,6 @@
       "from": "uuid@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
     },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-    },
     "vary": {
       "version": "1.1.1",
       "from": "vary@>=1.1.0 <1.2.0",
@@ -2709,28 +894,6 @@
       "version": "1.3.6",
       "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "from": "whatwg-fetch@>=0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
-    },
-    "which": {
-      "version": "1.2.14",
-      "from": "which@>=1.2.9 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "dependencies": {
-        "isexe": {
-          "version": "2.0.0",
-          "from": "isexe@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-        }
-      }
-    },
-    "which-module": {
-      "version": "1.0.0",
-      "from": "which-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
     },
     "window-size": {
       "version": "0.1.4",
@@ -2754,11 +917,6 @@
       "from": "wrap-ansi@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
     },
-    "wrappy": {
-      "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-    },
     "xtend": {
       "version": "4.0.1",
       "from": "xtend@>=4.0.0 <5.0.0",
@@ -2766,23 +924,13 @@
     },
     "y18n": {
       "version": "3.2.1",
-      "from": "y18n@>=3.2.1 <4.0.0",
+      "from": "y18n@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
     },
-    "yallist": {
-      "version": "2.1.2",
-      "from": "yallist@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
-    },
     "yargs": {
-      "version": "7.1.0",
-      "from": "yargs@>=7.0.1 <8.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
-    },
-    "yargs-parser": {
-      "version": "5.0.0",
-      "from": "yargs-parser@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+      "version": "3.32.0",
+      "from": "yargs@>=3.19.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,13 @@
     "pegjs": "0.7.0",
     "request": "2.79.0",
     "underscore": "1.8.3",
-    "winston": "2.3.0",
-    "nodeunit": "0.10.2",
+    "winston": "2.3.0"
+  },
+  "devDependencies": {
+    "mocha": "3.4.1",
+    "chai": "3.5.0",
+    "sinon": "2.3.1",
+    "mocha-junit-reporter": "1.13.0",
     "jshint": "2.9.4",
     "ejs-lint": "0.3.0",
     "jsonlint-cli": "1.0.1",

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -1,74 +1,21 @@
 /*jshint node: true, expr: false, boss: true */
 
 var fs = require('fs'),
-    // This also injects `Fiber` and `yield`
-    // Future = require('fibers/future'),
+    path = require('path'),
     request = require('request'),
-
-    // Loading kumascript modules can use index here, because the tests aren't
-    // a part of the package.
+    assert = require('chai').assert,
     kumascript = require('..'),
-    // ks_utils = kumascript.utils,
-    // ks_templates = kumascript.templates,
-    // ks_api = kumascript.api,
     ks_server = kumascript.server,
     ks_macros = kumascript.macros,
-    ks_test_utils = kumascript.test_utils;
+    ks_test_utils = kumascript.test_utils,
+    testRequestExpected = ks_test_utils.testRequestExpected;
 
-// // API that includes some things useful for testing.
-// var DemoAPI = ks_utils.Class(ks_api.BaseAPI, {
-//
-//     initialize: function (options) {
-//     },
-//
-//     echo: function (s) {
-//         return s;
-//     },
-//
-//     // snooze: demo of the fibers/future way to handle async in sync templates.
-//     snooze: function (ms) {
-//         var f = new Future(),
-//             s = new Date();
-//         setTimeout(function () {
-//             f['return'](); // HACK: Make jshint happy.
-//         }, ms);
-//         f.wait();
-//         return new Date() - s;
-//     },
-//
-//     random: function () {
-//         var content = '',
-//             f = new Future(),
-//             url = 'http://www.random.org/integers/?num=1&min=1&max=1000000&'+
-//                   'col=1&base=10&format=plain&rnd=new';
-//         request(url, function (error, resp, body) {
-//             content = body;
-//             f['return'](); // HACK: Make jshint happy.
-//         });
-//         f.wait();
-//         return content.trim();
-//     }
-//
-// });
-
-// Reusable fixture-based test runner
-function performTestRequest(test, expected_fn, result_url) {
-    fs.readFile(expected_fn, 'utf8', function (err, expected) {
-        var opts = {
-            url: result_url,
-            headers: { 'X-FireLogger': 'plaintext' }
-        };
-        request(opts, function (err, resp, result) {
-            test.equal(result.trim(), expected.trim());
-            test.done();
-        });
-    });
+function getURL(uri) {
+    return 'http://localhost:9000' + uri;
 }
 
-// Main test case starts here
-module.exports = {
-
-    setUp: function (next) {
+describe('test-api', function () {
+    beforeEach(function() {
         this.test_server = ks_test_utils.createTestServer();
         this.macro_processor = new ks_macros.MacroProcessor({
             macro_timeout: 500,
@@ -77,9 +24,9 @@ module.exports = {
             },
             loader: {
                 module: __dirname + '/../lib/kumascript/loaders',
-                class_name: 'HTTPLoader',
+                class_name: 'FileLoader',
                 options: {
-                    url_template: "http://localhost:9001/templates/{name}.ejs",
+                    root_dir: "tests/fixtures/templates",
                 }
             }
         });
@@ -90,93 +37,80 @@ module.exports = {
             macro_processor: this.macro_processor
         });
         this.server.listen();
-        next();
-    },
+    })
 
-    // Kill all the servers on teardown.
-    tearDown: function (next) {
+    afterEach(function () {
+        // Kill all the servers on teardown.
         this.server.close();
         this.test_server.close();
-        next();
-    },
+    })
 
-    "A template can include the output of executing another template with template()": function (test) {
-        var expected_fn = __dirname + '/fixtures/documents/template-exec-expected.txt',
-            result_url  = 'http://localhost:9000/docs/template-exec';
-        performTestRequest(test, expected_fn, result_url);
-    },
+    it('A template can include the output from another with template()', function (done) {
+        testRequestExpected(
+            getURL('/docs/template-exec'),
+            'documents/template-exec-expected.txt',
+            done,
+            function(resp, result, expected) {
+                assert.equal(result.trim(), expected.trim());
+            }
+        );
+    })
 
-    "A template can import methods and data from another template with require_macro()": function (test) {
-        var expected_fn = __dirname + '/fixtures/documents/library-test-expected.txt',
-            result_url  = 'http://localhost:9000/docs/library-test';
-        performTestRequest(test, expected_fn, result_url);
-    },
+    it('A template can import functions and data from another with require_macro()', function (done) {
+        testRequestExpected(
+            getURL('/docs/library-test'),
+            'documents/library-test-expected.txt',
+            done,
+            function(resp, result, expected) {
+                assert.equal(result.trim(), expected.trim());
+            }
+        );
+    })
 
-    "A template can import an npm module with require()": function (test) {
-        var expected_fn = __dirname + '/fixtures/documents/require-test-expected.txt',
-            result_url  = 'http://localhost:9000/docs/require-test';
-        performTestRequest(test, expected_fn, result_url);
-    },
+    it('A template can import an npm module with require()', function (done) {
+        testRequestExpected(
+            getURL('/docs/require-test'),
+            'documents/require-test-expected.txt',
+            done,
+            function(resp, result, expected) {
+                assert.equal(result.trim(), expected.trim());
+            }
+        );
+    })
 
-    "The server can be configured to auto-require some templates": function (test) {
-        var expected_fn = __dirname + '/fixtures/documents/autorequire-expected.txt',
-            result_url  = 'http://localhost:9000/docs/autorequire';
-        performTestRequest(test, expected_fn, result_url);
-    },
+    it('The server can be configured to auto-require some templates', function (done) {
+        testRequestExpected(
+            getURL('/docs/autorequire'),
+            'documents/autorequire-expected.txt',
+            done,
+            function(resp, result, expected) {
+                assert.equal(result.trim(), expected.trim());
+            }
+        );
+    })
 
-    "The API offers access to a cache for work done in templates": function (test) {
-        // This is not an integration test for memcache. Instead, it just ensures
-        // that the FakeMemcached stub gets used. If that works, then the right
-        // calls should get made to memcached.
-        var expected_fn = __dirname + '/fixtures/documents/memcache-expected.txt',
-            result_url  = 'http://localhost:9000/docs/memcache';
-        performTestRequest(test, expected_fn, result_url);
-    },
+    it('The API offers access to a cache for work done in templates', function (done) {
+        // This is not an integration test for memcache. Instead, it just
+        // ensures that the FakeMemcached stub gets used. If that works, then
+        // the right calls should get made to memcached.
+        testRequestExpected(
+            getURL('/docs/memcache'),
+            'documents/memcache-expected.txt',
+            done,
+            function(resp, result, expected) {
+                assert.equal(result.trim(), expected.trim());
+            }
+        );
+    })
 
-    "The API offers access to an RSS/Atom feed parser": function (test) {
-        var expected_fn = __dirname + '/fixtures/documents/feeds-expected.txt',
-            result_url  = 'http://localhost:9000/docs/feeds';
-        performTestRequest(test, expected_fn, result_url);
-    }
-
-    /* TODO: Fix this test. It relies on in-process macro processing, breaks
-     * horribly with child processes
-
-    "A sub-API installed into APIContext should be usable in a template": function (test) {
-        var $this = this,
-            t_fn = 'api1.txt',
-            t_cls = ks_templates.EJSTemplate;
-
-        // TODO: Refactor this template testing pattern into ks_test_utils.
-        fs.readFile(__dirname + '/fixtures/' + t_fn, function (err, data) {
-            if (err) { throw err; }
-
-            var parts = (''+data).split('---'),
-                src = parts.shift(),
-                expected = parts.shift(),
-                templates = {
-                    t1: new t_cls({source: parts.shift()}),
-                    t2: new t_cls({source: parts.shift()}),
-                    t3: new t_cls({source: parts.shift()})
-                },
-                loader_class = ks_test_utils.LocalLoader,
-                loader_options = { templates: templates },
-                mp = new ks_macros.MacroProcessor({
-                    loader_class: loader_class,
-                    loader_options: loader_options
-                }),
-                api_ctx = new ks_api.APIContext();
-
-            api_ctx.installAPI(DemoAPI, 'demo');
-
-            mp.process(src, api_ctx, function (err, result) {
-                test.equal(result.trim(), expected.trim());
-                test.done();
-            });
-
-        });
-
-    }
-    */
-
-};
+    it('The API offers access to an RSS/Atom feed parser', function (done) {
+        testRequestExpected(
+            getURL('/docs/feeds'),
+            'documents/feeds-expected.txt',
+            done,
+            function(resp, result, expected) {
+                assert.equal(result.trim(), expected.trim());
+            }
+        );
+    })
+});

--- a/tests/test-loaders.js
+++ b/tests/test-loaders.js
@@ -1,249 +1,94 @@
 /*jshint node: true, expr: false, boss: true */
 
 var fs = require('fs'),
-    async = require('async'),
-    nodeunit = require('nodeunit'),
-
-    morgan = require('morgan'),
-    express = require('express'),
-
+    assert = require('chai').assert,
     kumascript = require('..'),
     ks_loaders = kumascript.loaders,
-    ks_test_utils = kumascript.test_utils;
+    ks_test_utils = kumascript.test_utils,
+    readTestFixture = ks_test_utils.readTestFixture;
 
-var DEBUG = false;
+describe('test-loaders', function () {
 
-module.exports = nodeunit.testCase({
-
-    "Basic template loading should work": function (test) {
-
+    it('Basic macro loading should work', function (done) {
         var loader = new ks_test_utils.JSONifyLoader(),
             data = ["test123", ["alpha", "beta", "gamma"]],
             expected = JSON.stringify(data);
 
         loader.get(data[0], function (err, tmpl) {
-
-            test.ok(!err);
-            test.notEqual(typeof(tmpl), 'undefined');
-
-            tmpl.execute(data[1], {}, function (err, result) {
-                test.equal(result, expected);
-                test.done();
-            });
-
+            if (err) {
+                done(err);
+            } else {
+                assert.notEqual(typeof(tmpl), 'undefined');
+                tmpl.execute(data[1], {}, function (err, result) {
+                    if (!err) {
+                        assert.equal(result, expected);
+                    }
+                    done(err);
+                });
+            }
         });
+    })
 
-    },
+    it('The BaseLoader cannot return the macros', function () {
+        var loader = new ks_loaders.BaseLoader({}),
+            data = loader.macros_data();
+        assert.isNotOk(data['can_list_macros']);
+        assert.equal(0, data['macros'].length);
+    })
 
-    "The FileLoader should detect duplicates": function (test) {
-        test.throws(
+    it('The FileLoader can return the macros', function () {
+        var loader = new ks_loaders.FileLoader({
+                root_dir: 'tests/fixtures/templates'
+            }),
+            data = loader.macros_data(),
+            macro_len = data['macros'].length,
+            cssxref_found = false;
+        assert.isOk(data['can_list_macros']);
+        for (var i=0; i < macro_len; i++) {
+            if (data['macros'][i]['name'] == 'cssxref') {
+                cssxref_found = true;
+                assert.equal('cssxref.ejs', data['macros'][i]['filename']);
+            }
+        }
+        assert.isTrue(cssxref_found, data['macros']);
+    })
+
+    it('The FileLoader should detect duplicate macros', function () {
+        assert.throws(
             function() {
                 new ks_loaders.FileLoader({
                     root_dir: 'tests/fixtures'
                 });
             }
         );
-        test.done();
-    },
+    })
 
-    "Template loading via FileLoader": function (test) {
+    it('The FileLoader should load macros', function (done) {
         var loader = new ks_loaders.FileLoader({
             root_dir: 'tests/fixtures/templates'
         });
-        var tmpl_fn = __dirname + '/fixtures/templates/t1.ejs';
-        fs.readFile(tmpl_fn, function (err, expected) {
+        readTestFixture('templates/t1.ejs', done, function(expected) {
             loader.get('t1', function (err, tmpl) {
-                test.ifError(err);
                 if (!err) {
-                    test.equal(expected, tmpl.options.source);
+                    assert.equal(expected, tmpl.options.source);
                 }
-                test.done();
+                done(err);
             });
         });
-    },
+    })
 
-    "Template loading (with colons in name) via FileLoader": function (test) {
+    it('The FileLoader should load macros containing colons', function (done) {
         var loader = new ks_loaders.FileLoader({
-            root_dir: 'tests/fixtures/templates'
-        });
-        var tmpl_fn = __dirname +
-                      '/fixtures/templates/template-exec-template.ejs';
-        fs.readFile(tmpl_fn, function (err, expected) {
+                root_dir: 'tests/fixtures/templates'
+            }),
+            tmpl_fn = 'templates/template-exec-template.ejs';
+        readTestFixture(tmpl_fn, done, function(expected) {
             loader.get('TemPlaTe:eXec:teMplatE', function (err, tmpl) {
-                test.ifError(err);
                 if (!err) {
-                    test.equal(expected, tmpl.options.source);
+                    assert.equal(expected, tmpl.options.source);
                 }
-                test.done();
+                done(err);
             });
         });
-    },
-
-    "FileLoader can return the macros loaded": function (test) {
-        var loader = new ks_loaders.FileLoader({
-            root_dir: 'tests/fixtures/templates'
-        }),
-            data = loader.macros_data(),
-            macro_len = data['macros'].length,
-            cssxref_found = false;
-        test.ok(data['can_list_macros']);
-        for (var i=0; i < macro_len; i++) {
-            if (data['macros'][i]['name'] == 'cssxref') {
-                cssxref_found = true;
-                test.equal('cssxref.ejs', data['macros'][i]['filename']);
-            }
-        }
-        test.ok(cssxref_found, data['macros']);
-        test.done();
-    },
-
-    "Template loading via HTTP should work": function (test) {
-        var test_server = ks_test_utils.createTestServer();
-        var loader = new ks_loaders.HTTPLoader({
-            url_template: 'http://localhost:9001/templates/{name}.ejs'
-        });
-        var tmpl_fn = __dirname + '/fixtures/templates/t1.ejs';
-        fs.readFile(tmpl_fn, function (err, expected) {
-            loader.get('t1', function (err, tmpl) {
-                test.equal(expected, tmpl.options.source);
-                test_server.close();
-                test.done();
-            });
-        });
-    },
-
-    "Template loading via HTTP should retry on failure": function (test) {
-        var responses = [
-            { status: 500, body: 'INTERNAL SERVER ERROR' },
-            { status: 503, body: 'SERVICE UNAVAILABLE' },
-            { status: 204, body: 'NO CONTENT' },
-            { status: 200, body: '' },
-            { status: 200, body: 'OK' }
-        ];
-
-        var app = express();
-        if (DEBUG) {
-            app.use(morgan('TEST: :method :url :status :res[content-length]'));
-        }
-        app.use(function (req, res, mw_next) {
-            setTimeout(mw_next, 50);
-        });
-
-        var request_ct = 0;
-        app.get('/templates/*', function (req, res) {
-            var response = responses[request_ct++];
-            if (!response) {
-                res.status(405).send('Ran out of responses');
-            } else {
-                res.status(response.status).send(response.body);
-            }
-        });
-        var server = app.listen(9001);
-
-        var loader = new ks_loaders.HTTPLoader({
-            url_template: 'http://localhost:9001/templates/{name}',
-            cache_control: 'max-age=0',
-            max_retries: responses.length - 1
-        });
-
-        loader.get('testit', function (err, tmpl) {
-            test.ok(!!tmpl);
-            test.equal(responses[responses.length-1].body,
-                       tmpl.options.source);
-            server.close();
-            test.done();
-        });
-    },
-
-    "Template loading via HTTP should use conditional GET": function (test) {
-
-        var responses = [
-            { body: "EXPECTED #1",
-              lastmod: "Thu, 17 May 2012 18:13:54 GMT",
-              status_expected: 200 },
-            { body: "EXPECTED #1",
-              lastmod: "Thu, 17 May 2012 18:13:54 GMT" ,
-              status_expected: 304 },
-            { body: "EXPECTED #2",
-              lastmod: "Thu, 17 May 2012 19:24:32 GMT",
-              status_expected: 200 },
-            { body: "EXPECTED #2",
-              lastmod: "Thu, 17 May 2012 19:24:32 GMT",
-              status_expected: 304 },
-        ];
-
-        var app = express();
-        if (DEBUG) {
-            app.use(morgan('TEST: :method :url :status :res[content-length]'));
-        }
-        app.use(function (req, res, mw_next) {
-            setTimeout(mw_next, 50);
-        });
-
-        var request_ct = 0;
-        app.get('/templates/*', function (req, res) {
-            var response = responses[request_ct++];
-            if (!response) {
-                res.status(405).send('Ran out of responses');
-            } else {
-                var status = 200;
-
-                // Check if any conditional GET headers match
-                var ims = req.get('if-modified-since');
-                if (ims == response.lastmod) { status = 304; }
-
-                // Assert the expected conditional GET response condition.
-                test.equals(status, response.status_expected);
-
-                res.set('Last-Modified', response.lastmod);
-                res.status(status).send((304 == status) ? '' : response.body);
-            }
-        });
-        var server = app.listen(9001);
-
-        var loader = new ks_loaders.HTTPLoader({
-            url_template: 'http://localhost:9001/templates/{name}',
-            cache_control: 'max-age=0'
-        });
-
-        async.waterfall([
-            function (next) {
-                loader.get('testit', function (err, tmpl) {
-                    test.equal(responses[0].body, tmpl.options.source);
-                    next();
-                });
-            },
-            function (next) {
-                loader.get('testit', function (err, tmpl) {
-                    test.equal(responses[1].body, tmpl.options.source);
-                    next();
-                });
-            },
-            function (next) {
-                loader.get('testit', function (err, tmpl) {
-                    test.equal(responses[2].body, tmpl.options.source);
-                    next();
-                });
-            },
-            function (next) {
-                loader.get('testit', function (err, tmpl) {
-                    test.equal(responses[3].body, tmpl.options.source);
-                    next();
-                });
-            }
-        ], function (err) {
-            server.close();
-            test.done();
-        });
-
-    },
-
-    "TemplateLoader cannot return the macros": function (test) {
-        var loader = new ks_loaders.HTTPLoader({}),
-            data = loader.macros_data();
-        test.ok(!data['can_list_macros']);
-        test.equals(0, data['macros'].length);
-        test.done();
-    }
-
+    })
 });

--- a/tests/test-macros.js
+++ b/tests/test-macros.js
@@ -1,56 +1,63 @@
 /*jshint node: true, expr: false, boss: true */
 
 var fs = require('fs'),
+    path = require('path'),
     _ = require('underscore'),
-    nodeunit = require('nodeunit'),
+    assert = require('chai').assert,
     kumascript = require('..'),
-    ks_macros = kumascript.macros;
+    ks_macros = kumascript.macros,
+    ks_test_utils = kumascript.test_utils,
+    readTestFixture = ks_test_utils.readTestFixture;
 
-function processFixture(test, mp, fixture_path, next) {
-    fs.readFile(__dirname + '/fixtures/' + fixture_path, function (err, data) {
-        if (err) { throw err; }
-        var parts = (''+data).split('---'),
+function processFixture(mp, fixture_relpath, done, next) {
+    if (!next) {
+        function next(errors, result) {
+            assert.isOk(!errors, "There should be no errors");
+            done();
+        };
+    }
+
+    readTestFixture(fixture_relpath, done, function(data) {
+        var parts = data.split('---'),
             src = parts[0],
             expected = parts[1],
             ctx = {};
         if (parts.length < 2) {
-            throw "Please provide an expected result after '---' in " + fixture_path;
+            done("Please provide an expected result after '---' in " +
+                 fixture_relpath);
+        } else {
+            mp.process(src, ctx, function (errors, result) {
+                assert.equal(result.trim(), expected.trim());
+                return next(errors, result);
+            });
         }
-        mp.process(src, ctx, function (errors, result) {
-            test.equal(result.trim(), expected.trim());
-            return next(errors, result);
-        });
     });
 }
 
 function makeErrorHandlingTestcase(fixtureName) {
-    return function(test) {
+    return function(done) {
         var mp = new ks_macros.MacroProcessor({
             macro_timeout: 500,
             loader: {
                 module: __dirname + '/../lib/kumascript/test-utils',
                 class_name: 'JSONifyLoader',
-                options: { }
+                options: {}
             }
         });
-        processFixture(test, mp, fixtureName,
-            function (errors, result) {
-
-                test.ok(errors, "There should be errors");
-                test.equal(errors.length, 1, "There should be 1 error");
-
-                var e = errors[0];
-                test.equal(e.name, 'DocumentParsingError');
-                test.notEqual(null, e.message.match(
-                        /^Syntax error at line \d+, column \d+:[\s\S]*-+\^/));
-                test.done();
-            });
+        processFixture(mp, fixtureName, done, function (errors, result) {
+            assert.isOk(errors, "There should be errors");
+            assert.equal(errors.length, 1, "There should be 1 error");
+            var e = errors[0];
+            assert.equal(e.name, 'DocumentParsingError');
+            assert.notEqual(null, e.message.match(
+                    /^Syntax error at line \d+, column \d+:[\s\S]*-+\^/));
+            done();
+        });
     };
 }
 
-module.exports = nodeunit.testCase({
-
-    setUp: function (next) {
+describe('test-macros', function () {
+    beforeEach(function (done) {
         this.mp = new ks_macros.MacroProcessor({
             macro_timeout: 500,
             loader: {
@@ -59,72 +66,53 @@ module.exports = nodeunit.testCase({
                 options: { }
             }
         });
-        this.mp.startup(next);
-    },
+        this.mp.startup(done);
+    })
 
-    tearDown: function (next) {
-        this.mp.shutdown(next);
-    },
+    afterEach(function (done) {
+        this.mp.shutdown(done);
+    })
 
-    "Basic macro substitution should work": function (test) {
-        processFixture(test, this.mp, 'macros1.txt',
+    it('Basic macro substitution should work', function (done) {
+        processFixture(this.mp, 'macros1.txt', done);
+    })
+
+    it('Errors in document parsing should be handled gracefully and reported', function (done) {
+        processFixture(this.mp, 'macros-document-syntax-error.txt', done,
             function (errors, result) {
-                test.ok(!errors, "There should be no errors");
-                test.done();
-            });
-    },
-
-    "Errors in document parsing should be handled gracefully and reported": function (test) {
-        processFixture(test, this.mp, 'macros-document-syntax-error.txt',
-            function (errors, result) {
-                test.ok(errors, "There should be errors");
-                test.equal(errors.length, 1, "There should be 1 error");
+                assert.isOk(errors, "There should be errors");
+                assert.equal(errors.length, 1, "There should be 1 error");
 
                 var e = errors[0];
-                test.equal(e.name, 'DocumentParsingError');
-                test.equal(0, e.message.indexOf('Syntax error at line'));
+                assert.equal(e.name, 'DocumentParsingError');
+                assert.equal(0, e.message.indexOf('Syntax error at line'));
 
                 // Note: This is a *bit* brittle, but it makes sure the error
                 // indicator appears at the expected spot in the context lines
                 // included in the message.
-                test.equal(265, e.message.indexOf('-----------------------------^'));
-                test.done();
+                assert.equal(
+                    265, e.message.indexOf('-----------------------------^'));
+                done();
             });
-    },
+    })
 
-    "A numeric macro argument with a decimal point should not be trimmed to an integer": function (test) {
-        processFixture(test, this.mp, 'macros-decimal-argument.txt',
-            function (errors, result) {
-                test.ok(!errors, "There should be no errors");
-                test.done();
-            });
-    },
+    it('A numeric macro argument with a decimal point should not be trimmed to an integer', function (done) {
+        processFixture(this.mp, 'macros-decimal-argument.txt', done);
+    })
 
-    "Escaped single and double quotes should work in any quoting context": function (test) {
-        processFixture(test, this.mp, 'macros-document-escaped-quotes.txt',
-            function (errors, result) {
-                test.ok(!errors, "There should be no errors");
-                test.done();
-            });
-    },
+    it('Escaped single and double quotes should work in any quoting context', function (done) {
+        processFixture(this.mp, 'macros-document-escaped-quotes.txt', done);
+    })
 
-    "Empty parameters should be accepted": function (test) {
-        processFixture(test, this.mp, 'macros-document-empty-parameter.txt',
-            function (errors, result) {
-                test.ok(!errors, "There should be no errors");
-                test.done();
-            });
-    },
+    it('Empty parameters should be accepted', function (done) {
+        processFixture(this.mp, 'macros-document-empty-parameter.txt', done);
+    })
 
-    "Double right brace in a document should not result in a syntax error": function (test) {
-        processFixture(test, this.mp, 'macros-document-double-brace.txt',
-            function (errors, result) {
-                test.ok(!errors, "There should be no errors");
-                test.done();
-            });
-    },
+    it('Double right brace in a document should not result in a syntax error', function (done) {
+        processFixture(this.mp, 'macros-document-double-brace.txt', done);
+    })
 
-    "Errors in template loading, compilation, and execution should be handled gracefully and reported": function (test) {
+    it('Errors in template loading, compilation, and execution should be handled gracefully and reported', function (done) {
 
         var mp = new ks_macros.MacroProcessor({
             macro_timeout: 500,
@@ -144,8 +132,8 @@ module.exports = nodeunit.testCase({
             }
         });
         mp.startup(function () {
-            var events = [];
-            var ev_names = ['start', 'error', 'end',
+            var events = [],
+                ev_names = ['start', 'error', 'end',
                             'autorequireStart', 'autorequireEnd',
                             'templateLoadStart', 'templateLoadEnd',
                             'macroStart', 'macroEnd'];
@@ -155,7 +143,7 @@ module.exports = nodeunit.testCase({
                 });
             });
 
-            processFixture(test, mp, 'macros-broken-templates.txt',
+            processFixture(mp, 'macros-broken-templates.txt', done,
                 function (errors, result) {
                     var expected_errors = {
                         'broken1': ["TemplateLoadingError", "NOT FOUND"],
@@ -163,31 +151,29 @@ module.exports = nodeunit.testCase({
                         'broken3': ["TemplateExecutionError", "ERROR EXECUTING broken3"]
                     };
 
-                    test.ok(errors, "There should be errors");
+                    assert.isOk(errors, "There should be errors");
 
                     for (var idx=0; idx<errors.length; idx++) {
                         var error = errors[idx];
                         var expected = expected_errors[error.options.name];
-                        test.equal(error.name, expected[0]);
-                        test.ok((''+error.message).indexOf(expected[1]) !== -1);
+                        assert.equal(error.name, expected[0]);
+                        assert.isOk((''+error.message).indexOf(expected[1]) !== -1);
                         if ('broken3' == error.options.name) {
                             // Note: This is a *bit* brittle, but it makes sure the error
                             // indicator appears at the expected spot in the context lines
                             // included in the message.
-                            test.equal(264, error.message.indexOf('---------------------^'));
+                            assert.equal(264, error.message.indexOf('---------------------^'));
                         }
                     }
 
-                    mp.shutdown(function () {
-                        test.done();
-                    });
+                    mp.shutdown(done);
                 }
             );
         });
-    },
+    })
 
-    "Check for unrecoverable errors during initialize": function (test) {
-        test.doesNotThrow(
+    it('Check for unrecoverable errors during initialize', function (done) {
+        assert.doesNotThrow(
             function() {
                 // This should not throw an error.
                 new ks_macros.MacroProcessor({
@@ -201,7 +187,7 @@ module.exports = nodeunit.testCase({
                 });
             }
         );
-        test.throws(
+        assert.throws(
             function() {
                 // This should throw a "duplicate macros" error.
                 new ks_macros.MacroProcessor({
@@ -215,12 +201,12 @@ module.exports = nodeunit.testCase({
                 });
             }
         );
-        test.done();
-    },
+        done();
+    })
 
-    "Errors in ArgumentsJSON should be reported with line and column numbers":
-        makeErrorHandlingTestcase('macros-syntax-error-argumentsjson.txt'),
+    it('Errors in ArgumentsJSON should be reported with line and column numbers',
+        makeErrorHandlingTestcase('macros-syntax-error-argumentsjson.txt'))
 
-    "Errors in ArgumentList should be reported with line and column numbers":
-        makeErrorHandlingTestcase('macros-syntax-error-argumentlist.txt')
+    it('Errors in ArgumentList should be reported with line and column numbers',
+        makeErrorHandlingTestcase('macros-syntax-error-argumentlist.txt'))
 });

--- a/tests/test-templates.js
+++ b/tests/test-templates.js
@@ -1,21 +1,20 @@
 /*jshint node: true, expr: false, boss: true */
 
-var nodeunit = require('nodeunit'),
+var assert = require('chai').assert,
     kumascript = require('..'),
     ks_templates = kumascript.templates;
 
 // Main test case starts here
-module.exports = nodeunit.testCase({
-    "Embedded JS templates should work": function (test) {
+describe('test-templates', function () {
+    it('Embedded JS templates should work', function (done) {
         var tmpl = new ks_templates.EJSTemplate({
             source: '<%= one + two %>'
         });
-        tmpl.execute(
-            [], {one: 1, two: 2},
-            function (err, result) {
-                test.equal('3', result);
-                test.done();
+        tmpl.execute([], {one: 1, two: 2}, function (err, result) {
+            if (!err) {
+                assert.equal('3', result);
             }
-        );
-    }
+            done(err);
+        });
+    })
 });


### PR DESCRIPTION
This PR provides the foundation for building further tests for Kumascript, like tests for macros. I wanted to build on a popular, modern, well-supported test framework, and that came down to [Jasmine](https://jasmine.github.io/) or [Mocha](https://mochajs.org/). I thought Mocha had a slight edge mainly for two reasons: it was easier to use for JUnit reporting (just install the ``mocha-junit-reporter`` npm package), and allowed the flexibility to choose an assertion library.

During the course of this work, I realized that many of the existing ``nodeunit`` tests didn't properly use ``done`` within the asynchronous tests (which most are), so that led to more refactoring than I had originally planned. I also felt like I was back in the stone age of asynchronous programming (callbacks only), which makes it so difficult to write readable code (let's hope the new ``async/await`` is integrated into ``Node.js`` sooner rather than later).

* add "mocha" and related packages to "package.json"
  and create new "npm-shrinkwrap.json"
* update "README.md" to reflect "mocha" rather than
  "nodeunit"
* remove unused "HTTPLoader" from "loaders.js"
* update and refactor all tests
* add new functions to "test-utils.js"
* remove unused code from "test-utils.js"
* update Makefile and Jenkinsfile