### PR TITLE
Split all-examples from examples; es6-ify; change presentation for al…

### DIFF
--- a/macros/WebExtAllExamples.ejs
+++ b/macros/WebExtAllExamples.ejs
@@ -1,0 +1,60 @@
+
+<%
+
+/*
+The "examples.json" file from the https://github.com/mdn/webextensions-examples
+repository contains information about the examples living in that repository.
+
+This macro loads the "examples.json" file and uses it to build a table
+presenting that information.
+*/
+
+const examplesBaseUrl = "https://github.com/mdn/webextensions-examples/tree/master/";
+const allExamples = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/webextensions-examples/master/examples.json");
+const lang = env.locale;
+
+const s_name = mdn.localString({
+    "en-US": "Name"
+});
+
+const s_desc = mdn.localString({
+    "en-US": "Description"
+});
+
+const s_javascript_apis = mdn.localString({
+    "en-US": "JavaScript APIs"
+});
+
+function writeJavaScriptAPIs(apisJSON) {
+  let output = "";
+  for (let jsAPI of apisJSON) {
+    var link = `/${lang}/Add-ons/WebExtensions/API/${jsAPI.replace(".", "/")}`;
+    output += `<a href="${link}"><code>${jsAPI}</code></a><br/>`;
+  }
+  return output;
+}
+
+function writeAllExamples(examples) {
+  let output = "<table class=\"standard-table fullwidth-table\">";
+  output += `<tr>
+               <th>${s_name}</th>
+               <th>${s_desc}</th>
+               <th>${s_javascript_apis}</th>
+            </tr>`;
+
+  for (let example of examples) {
+    output += `<tr>`;
+    output += `  <td><a href="${examplesBaseUrl + example.name}">${example.name}</a></td>`;
+    output += `  <td>${example.description}</td>`;
+    output += `  <td>${writeJavaScriptAPIs(example.javascript_apis)}</td>`;
+    output += `</tr>`;
+  }
+  output += "</table>";
+  return output;
+}
+
+var output = writeAllExamples(allExamples);
+
+%>
+
+<%- output %>

--- a/macros/WebExtAllExamples.ejs
+++ b/macros/WebExtAllExamples.ejs
@@ -1,4 +1,3 @@
-
 <%
 
 /*
@@ -7,6 +6,10 @@ repository contains information about the examples living in that repository.
 
 This macro loads the "examples.json" file and uses it to build a table
 presenting that information.
+
+For example, the page at https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples
+is generated using this macro.
+
 */
 
 const examplesBaseUrl = "https://github.com/mdn/webextensions-examples/tree/master/";
@@ -25,10 +28,14 @@ const s_javascript_apis = mdn.localString({
     "en-US": "JavaScript APIs"
 });
 
+const s_webextension_api_path = mdn.localString({
+    "en-US": "Add-ons/WebExtensions/API"
+});
+
 function writeJavaScriptAPIs(apisJSON) {
   let output = "";
   for (let jsAPI of apisJSON) {
-    var link = `/${lang}/Add-ons/WebExtensions/API/${jsAPI.replace(".", "/")}`;
+    var link = `/${lang}/${s_webextension_api_path}/${jsAPI.replace(".", "/")}`;
     output += `<a href="${link}"><code>${jsAPI}</code></a><br/>`;
   }
   return output;

--- a/macros/WebExtExamples.ejs
+++ b/macros/WebExtExamples.ejs
@@ -1,16 +1,47 @@
 <%
 
-var allExamples = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/webextensions-examples/master/examples.json");
+/*
+The "examples.json" file from the https://github.com/mdn/webextensions-examples
+repository contains information about the examples living in that repository.
 
-var examplesInAPIHeading = $0 || "h3";
+This macro must be embedded in a WebExtensions API page, either of:
 
+* a "module" page (for example: "/en-US/Add-ons/WebExtensions/API/alarms" or "/en-US/Add-ons/WebExtensions/API/tabs")
+* an "API" page (for example: "/en-US/Add-ons/WebExtensions/API/alarms/create" or "/en-US/Add-ons/WebExtensions/API/tabs/executeScript")
+
+If it's embedded in a module page, it fetches all the examples that use any
+of the APIs in the given module, and outputs a list of links to those examples.
+
+If it's embedded in an API page, it fetches all the examples that use the
+given API, and outputs a list of links to those examples.
+
+It prepends this list with a header. By default the header is <h3>.
+The macro takes one optional argument, which is the name of the tag to use
+for the header. So if you want the header to be an <h2>, call it with "h2".
+*/
+
+const allExamples = mdn.fetchJSONResource("https://raw.githubusercontent.com/mdn/webextensions-examples/master/examples.json");
+const examplesBaseURL = "https://github.com/mdn/webextensions-examples/tree/master/";
+const desiredHeading = $0 || "h3";
+const lang = env.locale;
+
+const s_example_addons = mdn.localString({
+    "en-US": "Example Add-ons"
+});
+
+/*
+The `module` argument is the name of a JavaScript API module, like "alarms"
+or "tabs".
+
+This function returns an array of JSON objects representing examples which use
+any of the APIs under the given module.
+*/
 function getExamplesForModule(module) {
-  var examplesForModule = [];
-  for (var i = 0; i < allExamples.length; i++) {
-    var example = allExamples[i];
-    for (var j = 0; j < example.javascript_apis.length; j++) {
-      var apiUsed = example.javascript_apis[j].split(".")[0]
-      if (apiUsed === module) {
+  let examplesForModule = [];
+  for (let example of allExamples) {
+    for (let jsAPI of example.javascript_apis) {
+      jsAPI = jsAPI.split(".")[0];
+      if (jsAPI === module) {
         examplesForModule.push(example);
         break;
       }
@@ -19,13 +50,22 @@ function getExamplesForModule(module) {
   return examplesForModule;
 }
 
+/*
+The `module` argument is the name of a JavaScript API module, like "alarms"
+or "tabs".
+
+The `api` argument is the name of a JavaScript API in that module, like "create"
+or "executeScript".
+
+This function returns an array of JSON objects representing examples which the
+given API, like "alarms.create" or "tabs.executeScript".
+*/
 function getExamplesForAPI(module, api) {
-  var examplesForAPI = [];
-  var moduleAndAPI = module + "." + api;
-  for (var i = 0; i < allExamples.length; i++) {
-    var example = allExamples[i];
-    for (var j = 0; j < example.javascript_apis.length; j++) {
-      if (moduleAndAPI === example.javascript_apis[j]) {
+  let examplesForAPI = [];
+  let moduleAndAPI = `${module}.${api}`;
+  for (let example of allExamples) {
+    for (let jsAPI of example.javascript_apis) {
+      if (moduleAndAPI === jsAPI) {
         examplesForAPI.push(example);
         break;
       }
@@ -34,62 +74,35 @@ function getExamplesForAPI(module, api) {
   return examplesForAPI;
 }
 
-var lang = env.locale;
-
-function writeExampleDetails(examples) {
-  var output = "";
-  for (var i = 0; i < examples.length; i++) {
-    var example = examples[i]; 
-    output += "<hr/>";
-    output += "<h2>" + example.name + "</h2>";
-    var exampleUrl = "https://github.com/mdn/webextensions-examples/tree/master/" + example.name;
-    output += '<p><a href="' + exampleUrl + '">' + exampleUrl + '</a></p>';
-    output += '<p>' + example.description + '</p>';
-    
-    if (example.javascript_apis.length > 0) {
-      output += "<h3>" + "JavaScript APIs" + "</h3>";
-        output += "<ul>";
-        for (var k = 0; k < example.javascript_apis.length; k++) {
-          var link = "/" + lang + "/Add-ons/WebExtensions/API/" + example.javascript_apis[k].replace(".", "/");
-          output += '<li><a href="' + link + '"><code>' + example.javascript_apis[k] + '</code></a>';
-          output += "</li>";
-        }
-        output += "</ul>";
-    }
-  }
-  return output;
-}
-
-
+/*
+Given an array of JSON objects representing example add-ons,
+this function outputs:
+* a header
+* a list of links to the example source in GitHub
+*/
 function writeExampleLinks(examples) {
-  var output = "";
+  let output = "";
   if (examples.length > 0) {
-    output = "<" + examplesInAPIHeading + ">Example add-ons</" + examplesInAPIHeading + ">";
+    output = `<${desiredHeading}>${s_example_addons}</${desiredHeading}>`;
     output += "<ul>";
-    for (var i = 0; i < examples.length; i++) {
-      var example = examples[i];
-      output += "<li>";
-      var exampleURL = "https://github.com/mdn/webextensions-examples/tree/master/" + example.name;
-      output += '<a href="' + exampleURL + '">' + example.name + '</a>';
-      output += "</li>";
+    for (let example of examples) {
+      output += `<li><a href="${examplesBaseURL}${example.name}">${example.name}</a></li>`;
     }
     output += "</ul>";
   }
   return output;
 }
 
-var output = "";
+let output = "";
+let pieces = env.slug.split("/");
+let leaf = pieces[pieces.length-1];
+let parent = pieces[pieces.length-2];
 
-var pieces = env.slug.split("/");
-var leaf = pieces[pieces.length-1];
-var parent = pieces[pieces.length-2];
-var grandparent = pieces[pieces.length-3];
-
-if (leaf == "Examples") {
-  output = writeExampleDetails(allExamples);
-} else if (parent == "API") {
+// If the immediate parent of this page is named "API", assume we are in a module page, like "alarms" or "tabs".
+if (parent == "API") {
   output = writeExampleLinks(getExamplesForModule(leaf));
 }
+// Otherwise, assume we are in an API page, like "alarms.create" or "tabs.executeScript".
 else {
   output = writeExampleLinks(getExamplesForAPI(parent, leaf));
 }


### PR DESCRIPTION
…l-examples

[webextensions-examples](https://github.com/mdn/webextensions-examples)  contains a file "examples.json" that contains information about the examples. The macro [WebExtExamples.ejs](https://github.com/mozilla/kumascript/blob/master/macros/WebExtExamples.ejs) does two quite distinct things with that data:

1) generate an overview page listing all the examples: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples

2) generate lists of links from WebExt API reference pages to the examples that illustrate those APIs, like this: [tabs.executeScript](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/executeScript#Example_add-ons).

I've been thinking for a while that the presentation of the overview page is not ideal. On the [dev-addons list](https://mail.mozilla.org/pipermail/dev-addons/2017-May/002779.html), someone suggested using a tabular format for that page. I [tried it out](http://imgur.com/a/1bqo3?), and think it's a big improvement.

So that's the impetus to this PR. Initially I just updated the part of the old macro that built the overview page, using nice ES6 features to simplify it. But then I thought I should really ES6-ify the whole thing, rather than leave the macro inconsistent. But then I thought that since the macro is doing two quite different things with no real shared code, it would be better to split it. The also makes the code that figures out what to do less magical.

So now there's:
* a new macro "WebExtAllExamples.ejs" that just builds the overview page as a table
* modifies "WebExtExamples.ejs" to be ES6-y, and simplifies it by removing the overview-page stuff.
