### PR TITLE
Compat: Remove Servo, fix <code> markup for descriptions

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -373,8 +373,8 @@ function writeFeatureTable(json_subfeature_set, browserPlatformType, browserName
   // then all the other sub-features, one per row
   for (let row of Object.keys(json_subfeature_set)) {
     if (row != 'basic_support') {
-      var desc = json_subfeature_set[row].desc || row;
-      output += `<tr><td><code>${desc}</code></td>`
+      var desc = json_subfeature_set[row].desc || `<code>${row}</code>`;
+      output += `<tr><td>${desc}</td>`
       output += `${writeSupportCells(json_subfeature_set[row], compatNotes, browserNames)}</tr>`;
     }
   }

--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -58,8 +58,7 @@ const desktopBrowsers = {
   edge: 'Edge',
   ie: 'Internet Explorer',
   opera: 'Opera',
-  safari: 'Safari',
-  servo: 'Servo'
+  safari: 'Safari'
 };
 
 const mobileBrowsers = {


### PR DESCRIPTION
- Removes Servo
- Fixes markup for descriptions (the schema allows them to have `<code>` tags if necessary and the fallback if there is no description is the identifier which we should put in `<code>` tags). See https://developer.mozilla.org/en-US/docs/Web/CSS/background#Browser_compatibility which should be fixed by this.