### PR TITLE
move mdn-browser-compat-data from devDependencies to dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -238,7 +238,7 @@
     },
     "extend": {
       "version": "3.0.1",
-      "from": "extend@>=3.0.0 <3.1.0",
+      "from": "extend@3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
     },
     "extsprintf": {
@@ -463,6 +463,11 @@
       "version": "4.17.4",
       "from": "lodash@>=4.14.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+    },
+    "mdn-browser-compat-data": {
+      "version": "0.0.1",
+      "from": "mdn-browser-compat-data@>=0.0.0 <1.0.0",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.1.tgz"
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "pegjs": "0.7.0",
     "request": "2.79.0",
     "underscore": "1.8.3",
-    "winston": "2.3.0"
+    "winston": "2.3.0",
+    "mdn-browser-compat-data": "0.x"
   },
   "devDependencies": {
     "mocha": "3.4.1",
@@ -45,7 +46,6 @@
     "mocha-junit-reporter": "1.13.0",
     "jshint": "2.9.4",
     "ejs-lint": "0.3.0",
-    "jsonlint-cli": "1.0.1",
-    "mdn-browser-compat-data": "0.x"
+    "jsonlint-cli": "1.0.1"
   }
 }


### PR DESCRIPTION
In PR #188, the "mdn-browser-compat-data" npm package was mistakenly included in the "devDependencies" (when that section was added) when it should have remained in the "dependencies".