### PR TITLE
bug 1328839: improve npm package updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ WORKDIR /
 # "npm-shrinkwrap.json" file (if it exists).
 COPY *.json ./
 RUN npm install
+# Update any top-level npm packages listed in package.json,
+# as allowed by each package's given "semver".
+RUN npm update
 ENV NODE_PATH=/node_modules
 RUN chown -R kumascript:kumascript $NODE_PATH
 


### PR DESCRIPTION
This PR is a companion to [Kuma PR #4255](https://github.com/mozilla/kuma/pull/4255).


This PR updates the ``Dockerfile`` to use the [``npm update`` command](https://docs.npmjs.com/cli/update) to update any top-level npm packages listed in ``package.json``, while respecting each package's given [``semver``](https://docs.npmjs.com/getting-started/semantic-versioning). Since we are using versions like "0.x" for the ``mdn-browser-compat-data`` package within our ``package.json`` file, just by re-building the Docker file, we will grab the latest ``mdn-browser-compat-data`` package (say version "0.0.2") that satisfies the "0.x" ``semver`` even though the ``npm-shrinkwrap.json`` file has it locked-down to version "0.0.1".