### PR TITLE
{{AddonSidebar}} Theme section clean up

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -145,17 +145,6 @@ function currentPageIsUnder(root) {
     </li>
 
     <li><a href="<%=baseURL%>Themes"><strong>Themes</strong></a></li>
-    
-    <li><a href="<%=baseURL%>Themes/Background">Lightweight themes</a>
-      <ol>
-        <li><a href="<%=baseURL%>Themes/Background">Overview</a></li>
-      </ol>
-    </li>
-    <li><a href="<%=baseURL%>Themes/Complete_themes">Complete themes</a>
-      <ol>
-        <li><a href="<%=baseURL%>Themes">Overview</a></li>
-      </ol>
-    </li>
 
     <li><a href="<%=baseURL%>Distribution"><strong>Publishing add-ons</strong></a></li>
     <li><a href="<%=baseURL%>Distribution">Guides</a>


### PR DESCRIPTION
@atsay @wbamberg @jvillalobos 

Removed LWT and Complete Themes from Sidebar. Leaving "Themes" by itself.

Per issue #195