### PR TITLE
Adding "Creating an appealing add-on listing" 

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -162,6 +162,7 @@ function currentPageIsUnder(root) {
       <ol>
         <li><a href="<%=baseURL%>Distribution">Signing and distribution overview</a></li>
         <li><a href="https://addons.mozilla.org/developers/addon/submit/">Submit an add-on</a></li>
+        <li><a href="<%=baseURL%>Listing">Creating an appealing listing</a></li>
         <li><a href="<%=baseURL%>AMO/Policy/Reviews">Review policies</a></li>
         <li><a href="<%=baseURL%>AMO/Policy/Agreement">Developer agreement</a></li>
         <li><a href="<%=baseURL%>AMO/Policy/Featured">Featured add-ons</a></li>


### PR DESCRIPTION
Adding "Creating an appealing add-on listing" to the Publishing add-ons > Guides section