### PR TITLE
Fix sidebar link

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -120,7 +120,7 @@ function currentPageIsUnder(root) {
     <li><a href="<%=baseURL%>Firefox_for_Android">Getting started</a>
       <ol>
         <li><a href="<%=baseURL%>Firefox_for_Android/Walkthrough">Walkthrough</a></li>
-        <li><a href="<%=locale%>/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_with_WebIDE">Debugging</a></li>
+        <li><a href="/<%=locale%>/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_with_WebIDE">Debugging</a></li>
         <li><a href="<%=baseURL%>Firefox_for_Android/Code_snippets">Code snippets</a></li>
       </ol>
     </li>


### PR DESCRIPTION
The current sidebar contains a link with a relative URL, like:

    en-US/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_with_WebIDE

This gives us links like:

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/en-US/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_with_WebIDE

...which don't make sense.

This patch makes the URL absolute:

    /en-US/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_with_WebIDE
