### PR TITLE
bug 924958: first-pass at test framework for macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
 script:
   - make test
   - make lint-macros
+  - make test-macros
 
 notifications:
   email:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,11 @@ node {
           } finally {
             junit 'test-results.xml'
           }
+          try {
+            sh 'make test-macros VERSION=latest TEST_RUN_ARGS="--reporter mocha-junit-reporter"'
+          } finally {
+            junit 'test-results.xml'
+          }
         }
 
         stage('Push KumaScript Docker Image') {
@@ -31,6 +36,11 @@ node {
           sh 'make lint-macros'
           try {
             sh 'make test TEST_RUN_ARGS="--reporter mocha-junit-reporter"'
+          } finally {
+            junit 'test-results.xml'
+          }
+          try {
+            sh 'make test-macros TEST_RUN_ARGS="--reporter mocha-junit-reporter"'
           } finally {
             junit 'test-results.xml'
           }

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ DEIS_PROFILE ?= usw
 DEIS_APP ?= kumascript-dev
 PRIVATE_IMAGE ?= ${PRIVATE_REGISTRY}/${DEIS_APP}\:${VERSION}
 TEST_RUN_ARGS ?=
+TEST_RUN_TIMEOUT ?= 10000
 
 
 build:
@@ -25,7 +26,11 @@ run:
 
 test:
 	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \
-	    /node_modules/.bin/mocha ${TEST_RUN_ARGS} tests
+	    /node_modules/.bin/mocha --timeout=${TEST_RUN_TIMEOUT} ${TEST_RUN_ARGS} tests
+
+test-macros:
+	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \
+	    /node_modules/.bin/mocha --timeout=${TEST_RUN_TIMEOUT} ${TEST_RUN_ARGS} tests/macros
 
 lint:
 	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \

--- a/lib/kumascript/templates.js
+++ b/lib/kumascript/templates.js
@@ -65,11 +65,15 @@ var EJSTemplate = ks_utils.Class(BaseTemplate, {
     execute: function (args, ctx, next) {
         var compiled = this.compiled;
         Fiber(function () {
+            var success = false;
             try {
                 var result = compiled(ctx);
-                next(null, result.trim());
+                success = true;
             } catch (e) {
                 next(e, '');
+            }
+            if (success) {
+                next(null, result.trim());
             }
         }).run();
     }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "mocha": "3.4.1",
     "chai": "3.5.0",
+    "chai-as-promised": "7.0.0",
     "sinon": "2.3.1",
     "mocha-junit-reporter": "1.13.0",
     "jshint": "2.9.4",

--- a/tests/macros/test-deprecated_inline.js
+++ b/tests/macros/test-deprecated_inline.js
@@ -1,0 +1,69 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+var utils = require('./utils'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    assert = chai.assert,
+    itMacro = utils.itMacro,
+    describeMacro = utils.describeMacro;
+
+// Let's add "eventually" to assert so we can work with promises.
+chai.use(chaiAsPromised);
+
+describeMacro('deprecated_inline', function () {
+    itMacro('No arguments (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call(),
+            `<span title="This deprecated API should no longer be used, but will probably still work."><i class="icon-thumbs-down-alt"> </i></span>`
+        );
+    });
+    itMacro('"semver" string only (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('1.9.2'),
+            `<span class="inlineIndicator deprecated deprecatedInline" title="(Firefox 3.6 / Thunderbird 3.1 / Fennec 1.0)">Deprecated since Gecko 1.9.2</span>`
+        );
+    });
+    itMacro('Numeric version only (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call(45),
+            `<span class="inlineIndicator deprecated deprecatedInline" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
+        );
+    });
+    itMacro('Gecko-prefixed version (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('gecko45'),
+            `<span class="inlineIndicator deprecated deprecatedInline" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
+        );
+    });
+    itMacro('HTML-prefixed version (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('html4'),
+            `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated since <a href="/en-US/docs/HTML">HTML4</a></span>`
+        );
+    });
+    itMacro('JS-prefixed version (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('js1.7'),
+            `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated since <a href="/en-US/docs/JavaScript/New_in_JavaScript/1.7">JavaScript 1.7</a></span>`
+        );
+    });
+    itMacro('CSS-prefixed version (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('css2'),
+            `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated since CSS 2</span>`
+        );
+    });
+    itMacro('CSS-prefixed version (ja)', function (macro) {
+        macro.ctx.env.locale = 'ja';
+        return assert.eventually.equal(
+            macro.call('css2'),
+            `<span class="inlineIndicator deprecated deprecatedInline" title="">非推奨 CSS 2</span>`
+        );
+    });
+    itMacro('Nonsense-prefixed version (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('foobar13'),
+            `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated</span>`
+        );
+    });
+});

--- a/tests/macros/test-draft.js
+++ b/tests/macros/test-draft.js
@@ -1,0 +1,102 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+var utils = require('./utils'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    assert = chai.assert,
+    itMacro = utils.itMacro,
+    describeMacro = utils.describeMacro;
+
+// Let's add "eventually" to assert so we can work with promises.
+chai.use(chaiAsPromised);
+
+describeMacro('draft', function () {
+    itMacro('No arguments (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (es)', function (macro) {
+        macro.ctx.env.locale = 'es';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>Borrador</strong><br/>\n    Esta página no está completa.</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (fr)', function (macro) {
+        macro.ctx.env.locale = 'fr';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>Brouillon</strong><br/>\n    Cette page n&#39;est pas terminée.</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (ja)', function (macro) {
+        macro.ctx.env.locale = 'ja';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>草案</strong><br/>\n    このページは完成していません。</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (ko)', function (macro) {
+        macro.ctx.env.locale = 'ko';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>초안</strong><br/>\n    이 문서는 작성중입니다.</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (pl)', function (macro) {
+        macro.ctx.env.locale = 'pl';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>Szkic</strong><br/>\n    Strona ta nie jest jeszcze ukończona.</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (zh-CN)', function (macro) {
+        macro.ctx.env.locale = 'zh-CN';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>草案</strong><br/>\n    本页尚未完工.</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (zh-TW)', function (macro) {
+        macro.ctx.env.locale = 'zh-TW';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>編撰中</strong><br/>\n    本頁仍未完成</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (pt-PT)', function (macro) {
+        macro.ctx.env.locale = 'pt-PT';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>Esboço</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (pt-BR)', function (macro) {
+        macro.ctx.env.locale = 'pt-BR';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>Rascunho</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
+        );
+    });
+    itMacro('No arguments (ru)', function (macro) {
+        macro.ctx.env.locale = 'ru';
+        return assert.eventually.equal(
+            macro.call(),
+            `<div class="overheadIndicator draft">\n    <p><strong>Черновик</strong><br/>\n    Эта страница не завершена.</p>\n    \n</div>`
+        );
+    });
+    itMacro('One argument (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('The reason is shrouded in mystery (escattone).'),
+            `<div class="overheadIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    <em>The reason is shrouded in mystery (escattone).</em>\n</div>`
+        );
+    });
+    itMacro('One argument with embedded user profile (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('The reason is shrouded in mystery (~~escattone).'),
+            `<div class="overheadIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    <em>The reason is shrouded in mystery (<a href=\'https://developer.mozilla.org/profiles/escattone\'>escattone</a>).</em>\n</div>`
+        );
+    });
+});

--- a/tests/macros/test-httpheader.js
+++ b/tests/macros/test-httpheader.js
@@ -1,0 +1,77 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+var sinon = require('sinon'),
+    utils = require('./utils'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    assert = chai.assert,
+    itMacro = utils.itMacro,
+    describeMacro = utils.describeMacro,
+    beforeEachMacro = utils.beforeEachMacro;
+
+// Let's add "eventually" to assert so we can work with promises.
+chai.use(chaiAsPromised);
+
+describeMacro('httpheader', function () {
+    beforeEachMacro(function (macro) {
+        // Create a test fixture to mock the wiki.getPage function.
+        getPageStub = sinon.stub();
+        // Define various responses based on the input argument.
+        getPageStub.withArgs('/en-US/docs/Web/HTTP/Headers/accept').returns({
+            summary: "The <strong><code>Accept</code></strong> request HTTP header..."
+        });
+        getPageStub.withArgs('/ko/docs/Web/HTTP/Headers/Date').returns({
+            summary: "<strong><code>Date</code></strong> 일반 HTTP 헤더는 메시지가 만들어진 날짜와 시간을 포함합니다."
+        });
+        macro.ctx.wiki.getPage = getPageStub;
+    });
+    itMacro('No arguments (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call(),
+            `<a href="/en-US/docs/Web/HTTP/Headers/" title="The documentation about this has not yet been written; please consider contributing!"><code></code></a>`
+        );
+    });
+    itMacro('One argument (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('accept'),
+            `<a href="/en-US/docs/Web/HTTP/Headers/accept" title="The Accept request HTTP header..."><code>accept</code></a>`
+        );
+    });
+    itMacro('One argument (ko)', function (macro) {
+        macro.ctx.env.locale = 'ko';
+        return assert.eventually.equal(
+            macro.call('Date'),
+            `<a href="/ko/docs/Web/HTTP/Headers/Date" title="Date 일반 HTTP 헤더는 메시지가 만들어진 날짜와 시간을 포함합니다."><code>Date</code></a>`
+        );
+    });
+    itMacro('One unknown argument (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('fleetwood-mac'),
+            `<a href="/en-US/docs/Web/HTTP/Headers/fleetwood-mac" title="The documentation about this has not yet been written; please consider contributing!"><code>fleetwood-mac</code></a>`
+        );
+    });
+    itMacro('Two arguments (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('accept', 'xxx'),
+            `<a href="/en-US/docs/Web/HTTP/Headers/accept" title="The Accept request HTTP header..."><code>xxx</code></a>`
+        );
+    });
+    itMacro('Three arguments (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('accept', 'xxx', 'yyy'),
+            `<a href="/en-US/docs/Web/HTTP/Headers/accept#yyy" title=""><code>xxx.yyy</code></a>`
+        );
+    });
+    itMacro('Four arguments (code) (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('accept', 'xxx', 'yyy', false),
+            `<a href="/en-US/docs/Web/HTTP/Headers/accept#yyy" title=""><code>xxx.yyy</code></a>`
+        );
+    });
+    itMacro('Four arguments (not code) (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('accept', 'xxx', 'yyy', true),
+            `<a href="/en-US/docs/Web/HTTP/Headers/accept#yyy" title="">xxx.yyy</a>`
+        );
+    });
+});

--- a/tests/macros/test-httpheader.js
+++ b/tests/macros/test-httpheader.js
@@ -15,15 +15,7 @@ chai.use(chaiAsPromised);
 describeMacro('httpheader', function () {
     beforeEachMacro(function (macro) {
         // Create a test fixture to mock the wiki.getPage function.
-        getPageStub = sinon.stub();
-        // Define various responses based on the input argument.
-        getPageStub.withArgs('/en-US/docs/Web/HTTP/Headers/accept').returns({
-            summary: "The <strong><code>Accept</code></strong> request HTTP header..."
-        });
-        getPageStub.withArgs('/ko/docs/Web/HTTP/Headers/Date').returns({
-            summary: "<strong><code>Date</code></strong> 일반 HTTP 헤더는 메시지가 만들어진 날짜와 시간을 포함합니다."
-        });
-        macro.ctx.wiki.getPage = getPageStub;
+        macro.ctx.wiki.getPage = sinon.stub();
     });
     itMacro('No arguments (en-US)', function (macro) {
         return assert.eventually.equal(
@@ -32,13 +24,19 @@ describeMacro('httpheader', function () {
         );
     });
     itMacro('One argument (en-US)', function (macro) {
+        macro.ctx.wiki.getPage.withArgs('/en-US/docs/Web/HTTP/Headers/Accept').returns({
+            summary: "The <strong><code>Accept</code></strong> request HTTP header..."
+        });
         return assert.eventually.equal(
-            macro.call('accept'),
-            `<a href="/en-US/docs/Web/HTTP/Headers/accept" title="The Accept request HTTP header..."><code>accept</code></a>`
+            macro.call('Accept'),
+            `<a href="/en-US/docs/Web/HTTP/Headers/Accept" title="The Accept request HTTP header..."><code>Accept</code></a>`
         );
     });
     itMacro('One argument (ko)', function (macro) {
         macro.ctx.env.locale = 'ko';
+        macro.ctx.wiki.getPage.withArgs('/ko/docs/Web/HTTP/Headers/Date').returns({
+            summary: "<strong><code>Date</code></strong> 일반 HTTP 헤더는 메시지가 만들어진 날짜와 시간을 포함합니다."
+        });
         return assert.eventually.equal(
             macro.call('Date'),
             `<a href="/ko/docs/Web/HTTP/Headers/Date" title="Date 일반 HTTP 헤더는 메시지가 만들어진 날짜와 시간을 포함합니다."><code>Date</code></a>`
@@ -51,27 +49,39 @@ describeMacro('httpheader', function () {
         );
     });
     itMacro('Two arguments (en-US)', function (macro) {
+        macro.ctx.wiki.getPage.withArgs('/en-US/docs/Web/HTTP/Headers/Accept-Language').returns({
+            summary: "The <strong><code>Accept-Language</code></strong> request HTTP header..."
+        });
         return assert.eventually.equal(
-            macro.call('accept', 'xxx'),
-            `<a href="/en-US/docs/Web/HTTP/Headers/accept" title="The Accept request HTTP header..."><code>xxx</code></a>`
+            macro.call('Accept-Language', 'Accept-*'),
+            `<a href="/en-US/docs/Web/HTTP/Headers/Accept-Language" title="The Accept-Language request HTTP header..."><code>Accept-*</code></a>`
         );
     });
     itMacro('Three arguments (en-US)', function (macro) {
+        macro.ctx.wiki.getPage.withArgs('/en-US/docs/Web/HTTP/Headers/Accept-Language').returns({
+            summary: "The <strong><code>Accept-Language</code></strong> request HTTP header..."
+        });
         return assert.eventually.equal(
-            macro.call('accept', 'xxx', 'yyy'),
-            `<a href="/en-US/docs/Web/HTTP/Headers/accept#yyy" title=""><code>xxx.yyy</code></a>`
+            macro.call('Accept-Language', 'Accept-*', 'YYY'),
+            `<a href="/en-US/docs/Web/HTTP/Headers/Accept-Language#YYY" title=""><code>Accept-*.YYY</code></a>`
         );
     });
     itMacro('Four arguments (code) (en-US)', function (macro) {
+        macro.ctx.wiki.getPage.withArgs('/en-US/docs/Web/HTTP/Headers/Accept-Language').returns({
+            summary: "The <strong><code>Accept-Language</code></strong> request HTTP header..."
+        });
         return assert.eventually.equal(
-            macro.call('accept', 'xxx', 'yyy', false),
-            `<a href="/en-US/docs/Web/HTTP/Headers/accept#yyy" title=""><code>xxx.yyy</code></a>`
+            macro.call('Accept-Language', 'Accept-*', 'YYY', false),
+            `<a href="/en-US/docs/Web/HTTP/Headers/Accept-Language#YYY" title=""><code>Accept-*.YYY</code></a>`
         );
     });
     itMacro('Four arguments (not code) (en-US)', function (macro) {
+        macro.ctx.wiki.getPage.withArgs('/en-US/docs/Web/HTTP/Headers/Accept-Language').returns({
+            summary: "The <strong><code>Accept-Language</code></strong> request HTTP header..."
+        });
         return assert.eventually.equal(
-            macro.call('accept', 'xxx', 'yyy', true),
-            `<a href="/en-US/docs/Web/HTTP/Headers/accept#yyy" title="">xxx.yyy</a>`
+            macro.call('Accept-Language', 'Accept-*', 'YYY', true),
+            `<a href="/en-US/docs/Web/HTTP/Headers/Accept-Language#YYY" title="">Accept-*.YYY</a>`
         );
     });
 });

--- a/tests/macros/test-spec2.js
+++ b/tests/macros/test-spec2.js
@@ -1,0 +1,87 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+var utils = require('./utils'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    assert = chai.assert,
+    itMacro = utils.itMacro,
+    describeMacro = utils.describeMacro;
+
+// Let's add "eventually" to assert so we can work with promises.
+chai.use(chaiAsPromised);
+
+describeMacro('spec2', function () {
+    itMacro('CR (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('Upgrade Insecure Requests'),
+            '<span class="spec-CR">Candidate Recommendation</span>'
+        );
+    });
+    itMacro('ED (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('AmbientLight'),
+            '<span class="spec-ED">Editor&#39;s Draft</span>'
+        );
+    });
+    itMacro('WD (ja)', function (macro) {
+        macro.ctx.env.locale = 'ja';
+        return assert.eventually.equal(
+            macro.call('CSS3 Box'),
+            '<span class="spec-WD">草案</span>'
+        );
+    });
+    itMacro('REC (de)', function (macro) {
+        macro.ctx.env.locale = 'de';
+        return assert.eventually.equal(
+            macro.call('User Timing'),
+            '<span class="spec-REC">Empfehlung</span>'
+        );
+    });
+    itMacro('Draft (ru)', function (macro) {
+        macro.ctx.env.locale = 'ru';
+        return assert.eventually.equal(
+            macro.call('Async Function'),
+            '<span class="spec-Draft">Черновик</span>'
+        );
+    });
+    itMacro('Living (fr)', function (macro) {
+        macro.ctx.env.locale = 'fr';
+        return assert.eventually.equal(
+            macro.call('Background Sync'),
+            '<span class="spec-Living">Standard évolutif</span>'
+        );
+    });
+    itMacro('Standard (pt-BR)', function (macro) {
+        macro.ctx.env.locale = 'pt-BR';
+        return assert.eventually.equal(
+            macro.call('ES1'),
+            '<span class="spec-Standard">Padrão</span>'
+        );
+    });
+    itMacro('Obsolete (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('Typed Array'),
+            '<span class="spec-Obsolete">Obsolete</span>'
+        );
+    });
+    itMacro('Old-Transforms (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('CSS3 2D Transforms'),
+            '<span class="spec-WD">Working Draft</span>'
+        );
+    });
+    itMacro('Unknown (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('fleetwood mac'),
+            '<span class="spec-">Unknown</span>'
+        );
+    });
+    // Test that locale affects "unknown".
+    itMacro('Unknown (ja)', function (macro) {
+        macro.ctx.env.locale = 'ja';
+        return assert.eventually.equal(
+            macro.call('fleetwood mac'),
+            '<span class="spec-">不明</span>'
+        );
+    });
+});

--- a/tests/macros/test-specname.js
+++ b/tests/macros/test-specname.js
@@ -1,0 +1,108 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+var utils = require('./utils'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    assert = chai.assert,
+    itMacro = utils.itMacro,
+    describeMacro = utils.describeMacro;
+
+// Let's add "eventually" to assert so we can work with promises.
+chai.use(chaiAsPromised);
+
+describeMacro('specname', function () {
+    itMacro('One argument (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('Alarm API'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/" hreflang="en" lang="en" class="external" title="The \'Web Alarms API\' specification">Web Alarms API</a>`
+        );
+    });
+    itMacro('One argument (fr)', function (macro) {
+        macro.ctx.env.locale = 'fr';
+        return assert.eventually.equal(
+            macro.call('Alarm API'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/" hreflang="en" lang="en" class="external" title="La spécificaction 'Web Alarms API'">Web Alarms API</a>`
+        );
+    });
+    itMacro('One argument (de)', function (macro) {
+        macro.ctx.env.locale = 'de';
+        return assert.eventually.equal(
+            macro.call('Alarm API'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/" hreflang="en" lang="en" class="external" title="Die 'Web Alarms API' Spezifikation">Web Alarms API</a>`
+        );
+    });
+    itMacro('One argument (ru)', function (macro) {
+        macro.ctx.env.locale = 'ru';
+        return assert.eventually.equal(
+            macro.call('Alarm API'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/" hreflang="en" lang="en" class="external" title="Спецификация 'Web Alarms API'">Web Alarms API</a>`
+        );
+    });
+    itMacro('One argument (ja)', function (macro) {
+        macro.ctx.env.locale = 'ja';
+        return assert.eventually.equal(
+            macro.call('Alarm API'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/" hreflang="en" lang="en" class="external" title="Web Alarms APIの仕様書">Web Alarms API</a>`
+        );
+    });
+    itMacro('One argument (zh-CN)', function (macro) {
+        macro.ctx.env.locale = 'zh-CN';
+        return assert.eventually.equal(
+            macro.call('Alarm API'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/" hreflang="en" lang="en" class="external" title="Web Alarms API">Web Alarms API</a>`
+        );
+    });
+    itMacro('Two arguments (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('Alarm API', 'XXX'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external" title="The \'Web Alarms API\' specification">Web Alarms API</a>`
+        );
+    });
+    itMacro('Three arguments (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('Alarm API', 'XXX', 'YYY'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="en-US">The definition of \'YYY\' in that specification.</small></a>`
+        );
+    });
+    itMacro('Three arguments (fr)', function (macro) {
+        macro.ctx.env.locale = 'fr';
+        return assert.eventually.equal(
+            macro.call('Alarm API', 'XXX', 'YYY'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="fr">La définition de \'YYY\' dans cette spécification.</small></a>`
+        );
+    });
+    itMacro('Three arguments (de)', function (macro) {
+        macro.ctx.env.locale = 'de';
+        return assert.eventually.equal(
+            macro.call('Alarm API', 'XXX', 'YYY'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="de">Die Definition von \'YYY\' in dieser Spezifikation.</small></a>`
+        );
+    });
+    itMacro('Three arguments (ru)', function (macro) {
+        macro.ctx.env.locale = 'ru';
+        return assert.eventually.equal(
+            macro.call('Alarm API', 'XXX', 'YYY'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="ru">Определение \'YYY\' в этой спецификации.</small></a>`
+        );
+    });
+    itMacro('Three arguments (ja)', function (macro) {
+        macro.ctx.env.locale = 'ja';
+        return assert.eventually.equal(
+            macro.call('Alarm API', 'XXX', 'YYY'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="ja">YYY の定義</small></a>`
+        );
+    });
+    itMacro('Three arguments (zh-CN)', function (macro) {
+        macro.ctx.env.locale = 'zh-CN';
+        return assert.eventually.equal(
+            macro.call('Alarm API', 'XXX', 'YYY'),
+            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="zh-CN">YYY</small></a>`
+        );
+    });
+    itMacro('Unknown (en-US)', function (macro) {
+        return assert.eventually.equal(
+            macro.call('fleetwood mac'),
+            `<a href="about:unknown" hreflang="en" lang="en" class="external" title="The \'Unknown\' specification">Unknown</a>`
+        );
+    });
+});

--- a/tests/macros/test-specname.js
+++ b/tests/macros/test-specname.js
@@ -54,49 +54,49 @@ describeMacro('specname', function () {
     });
     itMacro('Two arguments (en-US)', function (macro) {
         return assert.eventually.equal(
-            macro.call('Alarm API', 'XXX'),
-            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external" title="The \'Web Alarms API\' specification">Web Alarms API</a>`
+            macro.call('CSS3 Transitions', '#animatable-css'),
+            `<a href="https://drafts.csswg.org/css-transitions/#animatable-css" hreflang="en" lang="en" class="external" title="The \'CSS Transitions\' specification">CSS Transitions</a>`
         );
     });
     itMacro('Three arguments (en-US)', function (macro) {
         return assert.eventually.equal(
-            macro.call('Alarm API', 'XXX', 'YYY'),
-            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="en-US">The definition of \'YYY\' in that specification.</small></a>`
+            macro.call('CSS3 Transitions', '#animatable-css', 'top'),
+            `<a href="https://drafts.csswg.org/css-transitions/#animatable-css" hreflang="en" lang="en" class="external">CSS Transitions<br><small lang="en-US">The definition of \'top\' in that specification.</small></a>`
         );
     });
     itMacro('Three arguments (fr)', function (macro) {
         macro.ctx.env.locale = 'fr';
         return assert.eventually.equal(
-            macro.call('Alarm API', 'XXX', 'YYY'),
-            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="fr">La définition de \'YYY\' dans cette spécification.</small></a>`
+            macro.call('CSS3 Transitions', '#animatable-css', 'top'),
+            `<a href="https://drafts.csswg.org/css-transitions/#animatable-css" hreflang="en" lang="en" class="external">CSS Transitions<br><small lang="fr">La définition de \'top\' dans cette spécification.</small></a>`
         );
     });
     itMacro('Three arguments (de)', function (macro) {
         macro.ctx.env.locale = 'de';
         return assert.eventually.equal(
-            macro.call('Alarm API', 'XXX', 'YYY'),
-            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="de">Die Definition von \'YYY\' in dieser Spezifikation.</small></a>`
+            macro.call('CSS3 Transitions', '#animatable-css', 'top'),
+            `<a href="https://drafts.csswg.org/css-transitions/#animatable-css" hreflang="en" lang="en" class="external">CSS Transitions<br><small lang="de">Die Definition von \'top\' in dieser Spezifikation.</small></a>`
         );
     });
     itMacro('Three arguments (ru)', function (macro) {
         macro.ctx.env.locale = 'ru';
         return assert.eventually.equal(
-            macro.call('Alarm API', 'XXX', 'YYY'),
-            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="ru">Определение \'YYY\' в этой спецификации.</small></a>`
+            macro.call('CSS3 Transitions', '#animatable-css', 'top'),
+            `<a href="https://drafts.csswg.org/css-transitions/#animatable-css" hreflang="en" lang="en" class="external">CSS Transitions<br><small lang="ru">Определение \'top\' в этой спецификации.</small></a>`
         );
     });
     itMacro('Three arguments (ja)', function (macro) {
         macro.ctx.env.locale = 'ja';
         return assert.eventually.equal(
-            macro.call('Alarm API', 'XXX', 'YYY'),
-            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="ja">YYY の定義</small></a>`
+            macro.call('CSS3 Transitions', '#animatable-css', 'top'),
+            `<a href="https://drafts.csswg.org/css-transitions/#animatable-css" hreflang="en" lang="en" class="external">CSS Transitions<br><small lang="ja">top の定義</small></a>`
         );
     });
     itMacro('Three arguments (zh-CN)', function (macro) {
         macro.ctx.env.locale = 'zh-CN';
         return assert.eventually.equal(
-            macro.call('Alarm API', 'XXX', 'YYY'),
-            `<a href="https://www.w3.org/2012/sysapps/web-alarms/XXX" hreflang="en" lang="en" class="external">Web Alarms API<br><small lang="zh-CN">YYY</small></a>`
+            macro.call('CSS3 Transitions', '#animatable-css', 'top'),
+            `<a href="https://drafts.csswg.org/css-transitions/#animatable-css" hreflang="en" lang="en" class="external">CSS Transitions<br><small lang="zh-CN">top</small></a>`
         );
     });
     itMacro('Unknown (en-US)', function (macro) {

--- a/tests/macros/utils.js
+++ b/tests/macros/utils.js
@@ -1,0 +1,121 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+// Provides utilities that as a whole constitute the macro test framework.
+
+var sinon = require('sinon'),
+    kumascript = require('../..'),
+    // Only do this once, since it crawls the file system.
+    loader = new kumascript.loaders.FileLoader();
+
+function createMacroTestObject(name, done) {
+    var ctx = new kumascript.api.APIContext({
+            errors: [],
+            source: '',
+            loader: loader,
+            log: sinon.spy(),
+            env: {
+                locale: 'en-US',
+                url: 'https://developer.mozilla.org/'
+            },
+            autorequire: {
+                'mdn': 'MDN-Common',
+                'Page': 'DekiScript-Page',
+                'String': 'DekiScript-String',
+                'Uri': 'DekiScript-Uri',
+                'Web': 'DekiScript-Web',
+                'Wiki': 'DekiScript-Wiki'
+            },
+        }),
+        macro = {};
+
+    // Give the test-case writer access to the macro's globals (ctx).
+    // For example, "macro.ctx.env.locale" can be manipulated to something
+    // other than 'en-US' or "macro.ctx.wiki.getPage" can be mocked
+    // using "sinon.stub()" to avoid network calls.
+    macro.ctx = ctx;
+
+    // Use this function to make test calls on the named macro. Its
+    // arguments become the arguments to the macro. It returns a promise.
+    macro.call = function () {
+        // Make the arguments accessible within the macro.
+        macro.ctx.setArguments(arguments);
+        return new Promise(function (resolve, reject) {
+            loader.get(name, function (err, tmpl, cache_hit) {
+                if (err) {
+                    // Loading errors should abort the test.
+                    throw err;
+                } else {
+                    // Actually execute the macro.
+                    tmpl.execute(null, macro.ctx, function (err, result) {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+                }
+            });
+        });
+    };
+
+    // Load the auto-required macros into the "ctx" object.
+    macro.ctx.performAutoRequire(done);
+
+    return macro;
+}
+
+// This is the essential function for testing macros. Use it as
+// you would use mocha's "describe", with the exception that the
+// first argument must be the name of the macro being tested.
+function describeMacro(macroName, runTests) {
+    describe(`test "${macroName}"`, function () {
+        beforeEach(function (done) {
+            this.macro = createMacroTestObject(macroName, done);
+        });
+        runTests();
+    });
+}
+
+// Syntactic sugar that avoids thinking about the mocha context "this".
+// Use this function as you would use mocha's "it", with the exception
+// that the callback function ("runTest" in this case) should accept a
+// single argument that is the macro test object.
+function itMacro(title, runTest) {
+    it(title, function () {
+        // Assumes that setup returns a promise (if async) or
+        // undefined (if synchronous).
+        return runTest(this.macro);
+    });
+}
+
+// Syntactic sugar that avoids thinking about the mocha context "this". Use
+// this function as you would use mocha's "beforeEach", with the exception
+// that the callback function ("setup" in this case) should accept a single
+// argument that is the macro test object.
+function beforeEachMacro(setup) {
+    beforeEach(function () {
+        // Assumes that setup returns a promise (if async) or
+        // undefined (if synchronous).
+        return setup(this.macro);
+    });
+}
+
+// Syntactic sugar that avoids thinking about the mocha context "this". Use
+// this function as you would use mocha's "afterEach", with the exception
+// that the callback function ("teardown" in this case) should accept a single
+// argument that is the macro test object.
+function afterEachMacro(teardown) {
+    afterEach(function () {
+        // Assumes that teardown returns a promise (if async) or
+        // undefined (if synchronous).
+        return teardown(this.macro);
+    });
+}
+
+// ### Exported public API
+module.exports = {
+    itMacro: itMacro,
+    describeMacro: describeMacro,
+    afterEachMacro: afterEachMacro,
+    beforeEachMacro: beforeEachMacro
+};

--- a/tests/macros/utils.js
+++ b/tests/macros/utils.js
@@ -28,14 +28,18 @@ function createMacroTestObject(name, done) {
         }),
         macro = {};
 
-    // Give the test-case writer access to the macro's globals (ctx).
-    // For example, "macro.ctx.env.locale" can be manipulated to something
-    // other than 'en-US' or "macro.ctx.wiki.getPage" can be mocked
-    // using "sinon.stub()" to avoid network calls.
+    /**
+     * Give the test-case writer access to the macro's globals (ctx).
+     * For example, "macro.ctx.env.locale" can be manipulated to something
+     * other than 'en-US' or "macro.ctx.wiki.getPage" can be mocked
+     * using "sinon.stub()" to avoid network calls.
+     */
     macro.ctx = ctx;
 
-    // Use this function to make test calls on the named macro. Its
-    // arguments become the arguments to the macro. It returns a promise.
+    /**
+     * Use this function to make test calls on the named macro. Its
+     * arguments become the arguments to the macro. It returns a promise.
+     */
     macro.call = function () {
         // Make the arguments accessible within the macro.
         macro.ctx.setArguments(arguments);
@@ -64,9 +68,11 @@ function createMacroTestObject(name, done) {
     return macro;
 }
 
-// This is the essential function for testing macros. Use it as
-// you would use mocha's "describe", with the exception that the
-// first argument must be the name of the macro being tested.
+/**
+ * This is the essential function for testing macros. Use it as
+ * you would use mocha's "describe", with the exception that the
+ * first argument must be the name of the macro being tested.
+ */
 function describeMacro(macroName, runTests) {
     describe(`test "${macroName}"`, function () {
         beforeEach(function (done) {
@@ -76,10 +82,12 @@ function describeMacro(macroName, runTests) {
     });
 }
 
-// Syntactic sugar that avoids thinking about the mocha context "this".
-// Use this function as you would use mocha's "it", with the exception
-// that the callback function ("runTest" in this case) should accept a
-// single argument that is the macro test object.
+/**
+ * Syntactic sugar that avoids thinking about the mocha context "this".
+ * Use this function as you would use mocha's "it", with the exception
+ * that the callback function ("runTest" in this case) should accept a
+ * single argument that is the macro test object.
+ */
 function itMacro(title, runTest) {
     it(title, function () {
         // Assumes that setup returns a promise (if async) or
@@ -88,10 +96,12 @@ function itMacro(title, runTest) {
     });
 }
 
-// Syntactic sugar that avoids thinking about the mocha context "this". Use
-// this function as you would use mocha's "beforeEach", with the exception
-// that the callback function ("setup" in this case) should accept a single
-// argument that is the macro test object.
+/**
+ * Syntactic sugar that avoids thinking about the mocha context "this". Use
+ * this function as you would use mocha's "beforeEach", with the exception
+ * that the callback function ("setup" in this case) should accept a single
+ * argument that is the macro test object.
+ */
 function beforeEachMacro(setup) {
     beforeEach(function () {
         // Assumes that setup returns a promise (if async) or
@@ -100,10 +110,12 @@ function beforeEachMacro(setup) {
     });
 }
 
-// Syntactic sugar that avoids thinking about the mocha context "this". Use
-// this function as you would use mocha's "afterEach", with the exception
-// that the callback function ("teardown" in this case) should accept a single
-// argument that is the macro test object.
+/**
+ * Syntactic sugar that avoids thinking about the mocha context "this". Use
+ * this function as you would use mocha's "afterEach", with the exception
+ * that the callback function ("teardown" in this case) should accept a single
+ * argument that is the macro test object.
+ */
 function afterEachMacro(teardown) {
     afterEach(function () {
         // Assumes that teardown returns a promise (if async) or


### PR DESCRIPTION
This PR defines a [set of functions](https://github.com/escattone/kumascript/blob/test-framework-for-macros-924958/tests/macros/utils.js) that constitute a first pass at a test framework for macros, as well as full test-suites for five frequently-used macros that show how to use the framework in practice. The goal was to be able to handle the complexity of testing sophisticated macros that often require mocking external services, while at the same time keeping things as simple as possible. I don't consider this a final product, but just the start of a conversation towards one.

* [tests/macros/utils.js](https://github.com/escattone/kumascript/blob/test-framework-for-macros-924958/tests/macros/utils.js) defines a set of functions
  that comprise a mocha-based test framework for
  simplifying the testing of Kumascript macros
* fixes the ``EJSTemplate``'s ``execute`` method so
  that it no longer re-calls its callback if the
  callback itself throws an error
* adds a ``make test-macros`` command
* adds an explicit timeout, which defaults to 10s,
  to the test commands (fixes an issue where some
  some tests would occasionally exceed the default
  mocha timeout of 2s)
* exercises the new test framework with tests (in
  the tests/macros/ directory) for five simple
  macros that are frequently used
* adds "chai-as-promised" npm package to "package.json"
* add ``make test-macros`` to the "Jenkinsfile" and
  ".travis.yml" files.