### PR TITLE
Fix CSSref macros to work with changed types data

### DIFF
--- a/macros/CSSRef.ejs
+++ b/macros/CSSRef.ejs
@@ -81,8 +81,11 @@ if (slug) {
             group = group.concat(data.atRules[name].groups);
         } else if (data.properties[name] && data.properties[name].groups) {
             group = group.concat(data.properties[name].groups);
-        } else if (isType(title) && data.types[title] && data.types[title].groups) {
-            group = group.concat(data.types[title].groups);
+        } else if (isType(title)) {
+          var cleanType = title.replace('<', '').replace('>', '');
+          if (data.types[cleanType] && data.types[cleanType].groups) {
+            group = group.concat(data.types[cleanType].groups);
+          }
         }
     }
 

--- a/macros/CSSRef.ejs
+++ b/macros/CSSRef.ejs
@@ -82,10 +82,14 @@ if (slug) {
         } else if (data.properties[name] && data.properties[name].groups) {
             group = group.concat(data.properties[name].groups);
         } else if (isType(title)) {
-          var cleanType = title.replace('<', '').replace('>', '');
-          if (data.types[cleanType] && data.types[cleanType].groups) {
-            group = group.concat(data.types[cleanType].groups);
-          }
+            var cleanType = title;
+            if (!(cleanType in data.types)) {
+                // https://github.com/mdn/data/pull/81 was merged
+                cleanType = title.replace('<', '').replace('>', '');
+            }
+            if (data.types[cleanType] && data.types[cleanType].groups) {
+                group = group.concat(data.types[cleanType].groups);
+            }
         }
     }
 

--- a/macros/CSS_Ref.ejs
+++ b/macros/CSS_Ref.ejs
@@ -114,9 +114,15 @@ if (types.some(function(type) { return type === "types"; })) {
             index[initial] = [];
         }
 
+        var label = type;
+        if (label.charAt(0) != "<") {
+            // https://github.com/mdn/data/pull/81 was merged
+            label =  "<" + type + ">";
+        }
+
         var item = {
             urlPath: "",
-            label: "<" + type + ">"
+            label: label
         };
 
         // Generate URL path regarding some special cases

--- a/macros/CSS_Ref.ejs
+++ b/macros/CSS_Ref.ejs
@@ -116,7 +116,7 @@ if (types.some(function(type) { return type === "types"; })) {
 
         var item = {
             urlPath: "",
-            label: type
+            label: "<" + type + ">"
         };
 
         // Generate URL path regarding some special cases


### PR DESCRIPTION
See https://github.com/mdn/data/pull/81 which changes the data structure of CSS 'types.json' to not use angle brackets anymore.

I couldn't really test the change in CSSRef.ejs due to bug https://bugzilla.mozilla.org/show_bug.cgi?id=1368134