### PR TITLE
Mailing list refs

### DIFF
--- a/macros/CommunityBox.ejs
+++ b/macros/CommunityBox.ejs
@@ -6,8 +6,10 @@
 //
 // Parameters:
 //  $0  Name of the topic/community
-//  $1  Name of the mailing list for the community
+//  $1  Name of the mailing list for the community.
+//      If this is an mdc/mdn list, it will be changed to https://discourse.mozilla-community.org/c/mdn in the DiscussionList macro
 //  $2  Name of the newsgroup for the community
+//      If this is an mdc/mdn newsgroup, it will be changed to https://discourse.mozilla-community.org/c/mdn in the DiscussionList macro
 //  $3  IRC channel name
 //  $4  String containing a list of URLs and descriptions for additional
 //      links (null if none).
@@ -105,7 +107,7 @@ switch(env.locale) {
         }
         break;
     case "ja":
-        headingStr = $0 + "コミュニティに参加してください"; 
+        headingStr = $0 + "コミュニティに参加してください";
         messageStr = "メーリングリスト／ニュースグループ:";
         messageNoteStr = "あなたの好きな方法でディスカッションに参加してください";
         if ($3) {
@@ -128,35 +130,35 @@ var haveExtra = $4 && ($4 != undefined);
 
 if (haveExtra || ircLink.length) {
     var list;
-        
+
     extraLinks = "<ul class='communitycontact'>";
-    
+
     if (ircLink.length) {
         extraLinks += "<li><strong>IRC: </strong>" + ircLink + " " + ircInfoStr + "</li>";
     }
-    
+
     if (haveExtra) {
         list = $4.split("||");      // a list of each item in "url|description" format
-        
+
         for (var i=0; i<list.length; i++) {
             // First, get the heading off the row and remove it
-            
+
             var headingEnd = list[i].indexOf("|");
             var heading = list[i].substr(0, headingEnd);
             var row = list[i].slice(headingEnd+1);
-            
+
             // Add the heading to the HTML
-            
+
             extraLinks += "<li><strong>" + heading + ": </strong>";
-            
+
             // Now split it up into all the terms for the heading
-            
+
             var links = row.split("++");
-            
+
             // Loop over all the links, adding them to the HTML
-        
+
             for (var j=0; j<links.length; j++) {
-                
+
                 // If the next entry in the list starts with a space, it's really part of
                 // this entry; this should fix cases of things like "C++" being in the
                 // text
@@ -166,24 +168,24 @@ if (haveExtra || ircLink.length) {
                         links.splice(j+1, 1);
                     }
                 }
-                
+
                 var comp = links[j].split("|");  // comp[0] is URL, 1 is text, 2 is description
                 var tooltipPart = "";
-            
+
                 if (comp[2]) {
                     tooltipPart = " title='" + comp[2] + "'";
                 }
                 extraLinks += "<a href='" + comp[0] + "'" + tooltipPart + ">" + comp[1] + "</a>";
-                
+
                 if (j < (links.length-1)) {
                     extraLinks += ", ";
                 }
             }
-            
+
             extraLinks += "</li>";
         }
     }
-    
+
     extraLinks += "</ul>";
 }
 

--- a/macros/DiscussionList.ejs
+++ b/macros/DiscussionList.ejs
@@ -175,7 +175,7 @@ var newsgroupFeedHTML = "";
 
 if($0.indexOf('mdn') !== -1 || $0.indexOf('mdc') !== -1) {
   mailingListURL = 'https://discourse.mozilla-community.org/c/mdn';
-  mailingHTML = "<li>" + web.link(mailingListURL, mailingList/newsgroup) + "</li>";
+  mailingHTML = "<li>" + web.link(mailingListURL, mailingList + '/' + newsgroup) + "</li>";
   newsgroupHTML = '';
   newsgroupFeedHTML = "<li>" + web.link('https://discourse.mozilla-community.org/c/mdn.rss', webFeed) + "</li>";
 } else {

--- a/macros/DiscussionList.ejs
+++ b/macros/DiscussionList.ejs
@@ -10,13 +10,12 @@
 //  $4  Twitter ID (null if none)
 //  $5  Stack Overflow tag (null if none)
 
-var lang = env.locale; /* get the page language */ ; 
-var mailingList, newsgroup, googleGroup, webFeed, stackOverflow, twitter;
+var lang = env.locale; /* get the page language */ ;
+var mailingList, newsgroup, webFeed, stackOverflow, twitter;
 
 /* Translation Targets
     * " mailingList"
 	* " newsgroup"
-	* " googleGroup"
 	* " webFeed"
     * " stackOverflow"
     * " twitter"
@@ -25,7 +24,6 @@ switch(lang) {
 	case 'ca':
 		mailingList = " com una llista de correu";
 		newsgroup = " com un grup de discussió";
-		googleGroup = " com un grup de Google";
 		webFeed = " com un canal web";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -33,7 +31,6 @@ switch(lang) {
 	case 'cs':
 		mailingList = " e-mailovou konferenci";
 		newsgroup = " diskuzní skupinu";
-		googleGroup = " Google Group";
 		webFeed = " RSS kanál";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -41,7 +38,6 @@ switch(lang) {
 	case 'de':
 		mailingList = "Mailing-Liste";
 		newsgroup = "Newsgroup";
-		googleGroup = "Google Group";
 		webFeed = "Web-Feed";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -49,7 +45,6 @@ switch(lang) {
 	case 'es':
 		mailingList = " como lista de correo";
 		newsgroup = " como grupo de noticias";
-		googleGroup = " como grupo de Google";
 		webFeed = " como RSS";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -57,7 +52,6 @@ switch(lang) {
 	case 'fi':
 		mailingList = " sähköposti listana";
 		newsgroup = " uutisryhmänä";
-		googleGroup = " Google Rymänä";
 		webFeed = " RSS kanál";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -65,7 +59,6 @@ switch(lang) {
 	case 'fr':
 		mailingList = " Liste de diffusion";
 		newsgroup = " 		newsgroup";
-		googleGroup = " Groupe Google";
 		webFeed = " Flux de syndication";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -73,7 +66,6 @@ switch(lang) {
 	case 'it':
 		mailingList = " Mailing list";
 		newsgroup = " Newsgroup";
-		googleGroup = " Google Groups";
 		webFeed = " Feed RSS";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -81,7 +73,6 @@ switch(lang) {
 	case 'ja':
 		mailingList = " メーリングリストとして";
 		newsgroup = " ニュースグループとして";
-		googleGroup = " Google Group として";
 		webFeed = " フィードとして";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -89,7 +80,6 @@ switch(lang) {
 	case 'ko':
 		mailingList = " 메일링 리스트";
 		newsgroup = " 뉴스그룹";
-		googleGroup = " Google 그룹";
 		webFeed = " 웹 Feed";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -97,7 +87,6 @@ switch(lang) {
 	case 'pl':
 		mailingList = " jako listę dyskusyjna";
 		newsgroup = " jako 		newsgroup";
-		googleGroup = " jako grupę Google";
 		webFeed = " jako kanał";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -105,7 +94,6 @@ switch(lang) {
     case 'ru':
     	mailingList = " Почтовая рассылка";
 		newsgroup = " newsgroup";
-		googleGroup = " Группы Google";
 		webFeed = " Новостная лента";
         stackOverflow = " Stack Overflow";
         twitter = " Твиттер";
@@ -113,7 +101,6 @@ switch(lang) {
 	case 'zh-CN':
 		mailingList = " 邮件列表";
 		newsgroup = " 新闻组";
-		googleGroup = " Google Group（中文）";
 		webFeed = " Web feed";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -121,7 +108,6 @@ switch(lang) {
 	case 'zh-TW':
 		mailingList = " 郵件討論";
 		newsgroup = " 新聞群組";
-		googleGroup = " Google 群組";
 		webFeed = " feed 消息來源";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -129,7 +115,6 @@ switch(lang) {
 	default:
 		mailingList = "Mailing list";
 		newsgroup = "Newsgroup";
-		googleGroup = "Google Group";
 		webFeed = "RSS feed";
         stackOverflow = " Stack Overflow";
         twitter = " Twitter";
@@ -156,16 +141,6 @@ if ($4) {
     twitHTML = "<li>" + web.link(twitterURL, twitter) + "</li>";
 }
 
-// Build the newsgroup and feed links, if newsgroup is given in $1
-
-var newsgroupHTML = "";
-var newsgroupFeedHTML = "";
-
-if ($1) {
-    newsgroupHTML = "<li>" + web.link('http://groups.google.com/group/' + $1, googleGroup) + "</li>";
-    newsgroupFeedHTML = "<li>" + web.link('http://groups.google.com/group/' + $1 + '/feeds', webFeed) + "</li>";
-}
-
 // Build the <ul> element
 
 var listElem = "<ul";
@@ -176,25 +151,32 @@ if ($2) {
 
 listElem += ">"; //Final ">" of the open <ul> tag
 
-// If the parameter looks like a complete URL, just return it.
-// Otherwise, prepend it with "https://lists.mozilla.org/listinfo/".
+// Specify a variable to contain the below link HTML
 
-function makeListTarget(param) {
+var mailingListURL = "";
+var mailingHTML = "";
+var newsgroupHTML = "";
+var newsgroupFeedHTML = "";
 
-    function startsWith (string, prefix) {
-        return string.slice(0, prefix.length) == prefix;
-    }
+// If the mailing list URL ($0) contains mdn or mdc, set the mailing lists and feed URLs to
+// The discourse options. Otherwise, set them to $0 and $1 (for non-MDN communities)
 
-    if (startsWith(param, 'https://') || startsWith(param, 'http://')) {
-        return param;
-    }
-    return  'https://lists.mozilla.org/listinfo/' + param;
+if($0.indexOf('mdn') !== -1 || $0.indexOf('mdc') !== -1) {
+  mailingListURL = 'https://discourse.mozilla-community.org/c/mdn';
+  mailingHTML = "<li>" + web.link(mailingListURL, mailingList/newsGroup) + "</li>";
+  newsgroupHTML = '';
+  newsgroupFeedHTML = "<li>" + web.link('https://discourse.mozilla-community.org/c/mdn.rss', webFeed) + "</li>";
+} else {
+  mailingListURL = $0;
+  mailingHTML = "<li>" + web.link(mailingListURL, mailingList) + "</li>";
+  newsgroupHTML = "<li>" + web.link('http://groups.google.com/group/' + $1, newsGroup) + "</li>";
+  newsgroupFeedHTML = "<li>" + web.link('http://groups.google.com/group/' + $1 + '/feeds', webFeed) + "</li>";
 }
 
 %>
 
 <%-listElem %>
-  <li><%- web.link(makeListTarget($0), mailingList) %></li>
+  <%- mailingHTML %>
   <%- twitHTML %>
   <%- soHTML %>
   <%- newsgroupHTML %>

--- a/macros/DiscussionList.ejs
+++ b/macros/DiscussionList.ejs
@@ -151,6 +151,18 @@ if ($2) {
 
 listElem += ">"; //Final ">" of the open <ul> tag
 
+
+function makeListTarget(param) {
+    function startsWith (string, prefix) {
+        return string.slice(0, prefix.length) == prefix;
+    }
+    if (startsWith(param, 'https://') || startsWith(param, 'http://')) {
+        return param;
+    }
+    return  'https://lists.mozilla.org/listinfo/' + param;
+}
+
+
 // Specify a variable to contain the below link HTML
 
 var mailingListURL = "";
@@ -168,7 +180,7 @@ if($0.indexOf('mdn') !== -1 || $0.indexOf('mdc') !== -1) {
   newsgroupFeedHTML = "<li>" + web.link('https://discourse.mozilla-community.org/c/mdn.rss', webFeed) + "</li>";
 } else {
   mailingListURL = $0;
-  mailingHTML = "<li>" + web.link(mailingListURL, mailingList) + "</li>";
+  mailingHTML = "<li>" + web.link(makeListTarget(mailingListURL), mailingList) + "</li>";
   newsgroupHTML = "<li>" + web.link('http://groups.google.com/group/' + $1, newsGroup) + "</li>";
   newsgroupFeedHTML = "<li>" + web.link('http://groups.google.com/group/' + $1 + '/feeds', webFeed) + "</li>";
 }

--- a/macros/DiscussionList.ejs
+++ b/macros/DiscussionList.ejs
@@ -175,13 +175,13 @@ var newsgroupFeedHTML = "";
 
 if($0.indexOf('mdn') !== -1 || $0.indexOf('mdc') !== -1) {
   mailingListURL = 'https://discourse.mozilla-community.org/c/mdn';
-  mailingHTML = "<li>" + web.link(mailingListURL, mailingList/newsGroup) + "</li>";
+  mailingHTML = "<li>" + web.link(mailingListURL, mailingList/newsgroup) + "</li>";
   newsgroupHTML = '';
   newsgroupFeedHTML = "<li>" + web.link('https://discourse.mozilla-community.org/c/mdn.rss', webFeed) + "</li>";
 } else {
   mailingListURL = $0;
   mailingHTML = "<li>" + web.link(makeListTarget(mailingListURL), mailingList) + "</li>";
-  newsgroupHTML = "<li>" + web.link('http://groups.google.com/group/' + $1, newsGroup) + "</li>";
+  newsgroupHTML = "<li>" + web.link('http://groups.google.com/group/' + $1, newsgroup) + "</li>";
   newsgroupFeedHTML = "<li>" + web.link('http://groups.google.com/group/' + $1 + '/feeds', webFeed) + "</li>";
 }
 

--- a/macros/TopicBox.ejs
+++ b/macros/TopicBox.ejs
@@ -8,7 +8,7 @@
 //  $0  Name of the topic
 
 var ircChannelName = "mdn";
-var mlName = "MDN";
+var mlName = "mdn";
 var ngName = "mozilla.dev.mdc";
 var driver = {};
 
@@ -88,7 +88,7 @@ switch(env.locale) {
         headingStr = "Help the '" + $0 + "' documentation project…";
         statusStr = "Look at the current <a href='/en-US/docs/" + driver.docStatus + "'>status</a> of the '" + $0 +"' documentation.";
         topicDriverStr = "Topic driver : <a href='/en-US/profiles/" + driver.mdnPseudo + "'>" + driver.name + "</a> (IRC nickname: " + driver.ircPseudo + ")";
-        ircStr = "Don't hesitate to contact us on " + ircLink + " or on the <em>" + mlName + "</em> discourse group/list:";
+        ircStr = "Don't hesitate to contact us on " + ircLink + " or on the <em>" + mlName.toUpperCase() + "</em> discourse group/list:";
         break;
 }
 %>

--- a/macros/TopicBox.ejs
+++ b/macros/TopicBox.ejs
@@ -8,7 +8,7 @@
 //  $0  Name of the topic
 
 var ircChannelName = "mdn";
-var mlName = "dev-mdc";
+var mlName = "MDN";
 var ngName = "mozilla.dev.mdc";
 var driver = {};
 
@@ -52,7 +52,7 @@ switch ($0) {
                         "docStatus" : "MDN/Doc_status"
                     };
 }
-                   
+
 var headingStr = "";
 var topicDriverStr = "";
 var ircStr = "";
@@ -88,7 +88,7 @@ switch(env.locale) {
         headingStr = "Help the '" + $0 + "' documentation project…";
         statusStr = "Look at the current <a href='/en-US/docs/" + driver.docStatus + "'>status</a> of the '" + $0 +"' documentation.";
         topicDriverStr = "Topic driver : <a href='/en-US/profiles/" + driver.mdnPseudo + "'>" + driver.name + "</a> (IRC nickname: " + driver.ircPseudo + ")";
-        ircStr = "Don't hesitate to contact us on " + ircLink + " or on the <em>" + mlName + "</em> mailing-list:";
+        ircStr = "Don't hesitate to contact us on " + ircLink + " or on the <em>" + mlName + "</em> discourse group/list:";
         break;
 }
 %>


### PR DESCRIPTION
This PR is designed to fix the issue of us having community box macros pointing to our mailing lists, etc., and those boxes becoming out of date now we've moved to the new discourse. The updates detect when mdn/mdc mailing lists/newsgroups/rss feeds have been specified, and update the specified values to the discourse equivalents.

If mdn/mdc items are not specified, the boxes appear as they did before.