### PR TITLE
bug 1372952: add liveness/readiness endpoints

### DIFF
--- a/lib/kumascript/loaders.js
+++ b/lib/kumascript/loaders.js
@@ -3,7 +3,7 @@
 // This module houses the machinery for template loading, compilation, and
 // caching.
 
-/*jshint node: true, expr: false, boss: true */
+/*jshint node: true, esversion: 6, expr: false, boss: true */
 
 // ### Prerequisites
 var fs = require('fs'),
@@ -11,7 +11,6 @@ var fs = require('fs'),
     _ = require('underscore'),
     Memcached = require('memcached'),
     ks_templates = require(__dirname + '/templates'),
-    ks_caching = require(__dirname + '/caching'),
     ks_utils = require(__dirname + '/utils');
 
 // ### BaseLoader
@@ -124,7 +123,6 @@ var BaseLoader = ks_utils.Class({
         // By default, loader doesn't know what macros are available
         return [];
     }
-
 });
 
 // ### FileLoader
@@ -176,6 +174,16 @@ var FileLoader = ks_utils.Class(BaseLoader, {
         while (dirs.length > 0) {
             dir = dirs.shift();
             fs.readdirSync(dir).forEach(processFilename);
+        }
+
+        if (_.isEmpty(template_map)) {
+            // Let's throw an error if no macros could be discovered, since
+            // for now this is the only time we check and this loader is
+            // useless if there are no macros.
+            var root_dir = path.resolve(repo_dir, this.options.root_dir);
+            throw new Error(
+                `no macros could be found in "${root_dir}"`
+            );
         }
 
         if (!(_.isEmpty(duplicates))) {
@@ -232,7 +240,6 @@ var FileLoader = ks_utils.Class(BaseLoader, {
         }
         return macros;
     }
-
 });
 
 // ### Exported public API

--- a/lib/kumascript/server.js
+++ b/lib/kumascript/server.js
@@ -2,7 +2,7 @@
 //
 // Provides the HTTP service for document processing
 
-/*jshint node: true, expr: false, boss: true */
+/*jshint node: true, esversion: 6, expr: false, boss: true */
 
 var ks_conf = require(__dirname + '/conf');
 
@@ -10,7 +10,9 @@ var newrelic_conf = ks_conf.nconf.get('newrelic');
 if (newrelic_conf && newrelic_conf.license_key) require('newrelic');
 
 // ### Prerequisites
-var _ = require('underscore'),
+var url = require('url'),
+    _ = require('underscore'),
+    request = require('request'),
     Memcached = require('memcached'),
     express = require('express'),
     morgan = require('morgan'),
@@ -126,6 +128,8 @@ var Server = ks_utils.Class({
             app.get('/docs/*', _.bind($this.docs_GET, $this));
             app.post('/docs/', _.bind($this.docs_POST, $this));
             app.get('/macros/?', _.bind($this.macros_list_GET, $this));
+            app.get('/healthz/?', _.bind($this.liveness_GET, $this));
+            app.get('/readiness/?', _.bind($this.readiness_GET, $this));
         });
     },
 
@@ -231,6 +235,52 @@ var Server = ks_utils.Class({
         res.json(data);
     },
 
+    /**
+     * A "liveness" endpoint for use by Kubernetes or other
+     * similar systems. A successful response from this endpoint
+     * simply proves that this Express app is up and running. It
+     * doesn't mean that its supporting services (like the macro
+     * loader and the document service) can be successfully used
+     * from this service.
+     */
+    liveness_GET: function (req, res) {
+        res.sendStatus(204);
+    },
+
+    /**
+     * A "readiness" endpoint for use by Kubernetes or other
+     * similar systems. A successful response from this endpoint goes
+     * a step further and means not only that this Express app is up
+     * and running, but also that one or more macros have been found
+     * and that the document service is ready.
+     */
+    readiness_GET: function (req, res) {
+        var msg = 'service unavailable ',
+            parts = url.parse(this.options.document_url_template),
+            kumaReadiness = `${parts.protocol}//${parts.host}/readiness`;
+
+        // First, check that we can load some macros.
+        try {
+            // If there are no macros or duplicate macros, an error
+            // will be thrown.
+            this.macro_processor.makeLoader();
+        } catch(err) {
+            msg += `(macro loader error) (${err})`;
+            res.status(503).send(msg);
+            return;
+        }
+
+        // Finally, check that the document service is ready.
+        request.get(kumaReadiness, function (err, resp, body) {
+            if (!err && ((resp.statusCode >= 200) && (resp.statusCode < 400))) {
+                res.sendStatus(204);
+            } else {
+                var reason = err ? err : body;
+                msg += `(document service is not ready) (${reason})`;
+                res.status(503).send(msg);
+            }
+        });
+    },
 
     // #### _evalMacros()
     //

--- a/tests/test-loaders.js
+++ b/tests/test-loaders.js
@@ -1,6 +1,7 @@
-/*jshint node: true, expr: false, boss: true */
+/*jshint node: true, mocha: true, esversion: 6, expr: false, boss: true */
 
 var fs = require('fs'),
+    path = require('path'),
     assert = require('chai').assert,
     kumascript = require('..'),
     ks_loaders = kumascript.loaders,
@@ -53,13 +54,31 @@ describe('test-loaders', function () {
         assert.isTrue(cssxref_found, data['macros']);
     })
 
+    it('The FileLoader should detect no macros', function () {
+        var macro_dir = 'tests/no-macros-in-here';
+        fs.mkdirSync(macro_dir);
+        try {
+            assert.throws(
+                function() {
+                    new ks_loaders.FileLoader({
+                        root_dir: macro_dir
+                    });
+                },
+                /no macros could be found in .+/
+            );
+        } finally {
+            fs.rmdirSync(macro_dir);
+        }
+    });
+
     it('The FileLoader should detect duplicate macros', function () {
         assert.throws(
             function() {
                 new ks_loaders.FileLoader({
                     root_dir: 'tests/fixtures'
                 });
-            }
+            },
+            /duplicate macros:[\s\S]+/
         );
     })
 

--- a/tests/test-server.js
+++ b/tests/test-server.js
@@ -19,9 +19,6 @@ describe('test-server', function () {
     beforeEach(function() {
         // Build both a kumascript instance and a document server for tests.
         this.test_server = ks_test_utils.createTestServer();
-        this.test_server.get('/healthz/?', function (req, res) {
-            res.sendStatus(204);
-        });
         this.test_server.get('/readiness/?', function (req, res) {
             res.sendStatus(204);
         });


### PR DESCRIPTION
This PR adds "liveness" and "readiness" endpoints to KumaScript for use by Kubernetes or any similar control system.

* add "liveness"/"readiness" endpoints and their tests
* throw error if ``FileLoader`` is unable to find any macros during initialization, and add test for that case

I wrote the "readiness" endpoint under the idea that KumaScript is not ready unless it satisfies three things:
* it is up and running (the Express app can accept and respond to requests)
* it can load one or more macros
* it knows the document service (Kuma) is ready

Just for reference, Kuma's "readiness" only depends on two things:
* it is up and running (the Django app can accept and respond to requests)
* it can query the database