### PR TITLE
Adding Gamepad Extensions spec to SpecName/Spec2

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -559,6 +559,10 @@ var specList = {
         name : 'Gamepad',
         url  : 'https://w3c.github.io/gamepad/'
     },
+    'GamepadExtensions':{
+        name : 'Gamepad Extensions',
+        url  : 'https://w3c.github.io/gamepad/extensions.html'
+    },
     'Geolocation': {
         name : 'Geolocation API',
         url  : 'https://dev.w3.org/geo/api/spec-source.html'

--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -150,6 +150,7 @@ var status = {
   'Frame Timing'               : 'ED',
   'Fullscreen'                 : 'Living',
   'Gamepad'                    : 'WD',
+  'GamepadExtensions'          : 'ED',
   'Geolocation'                : 'REC',
   'Geometry Interfaces'        : 'CR',
   'Highres Time'               : 'REC',


### PR DESCRIPTION
This API covers stuff like getting haptic feedback from controllers, and pose information from WebVR controllers