### PR TITLE
Compat: remove parenthesis around No; add title attribute

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -103,10 +103,12 @@ function getVersionString(versionInfo) {
               style="color: rgb(255, 153, 0);">${localize(compatStrings, 'supportsShort_unknown')}</span>`;
       break;
     case true:
-      return `<span style="color: #888">(${localize(compatStrings, 'supportsShort_yes')})</span>`;
+      return `<span title="${localize(compatStrings, 'supportsShort_yes_title')}"
+              style="color: #888">(${localize(compatStrings, 'supportsShort_yes')})</span>`;
       break;
     case false:
-      return `<span style="color: #f00">(${localize(compatStrings, 'supportsShort_no')})</span>`;
+      return `<span title="${localize(compatStrings, 'supportsLong_no')}"
+              style="color: #f00">${localize(compatStrings, 'supportsShort_no')}</span>`;
       break;
     default:
       return versionInfo;

--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -104,7 +104,7 @@ function getVersionString(versionInfo) {
       break;
     case true:
       return `<span title="${localize(compatStrings, 'supportsShort_yes_title')}"
-              style="color: #888">(${localize(compatStrings, 'supportsShort_yes')})</span>`;
+              style="color: #888">${localize(compatStrings, 'supportsShort_yes')}</span>`;
       break;
     case false:
       return `<span title="${localize(compatStrings, 'supportsLong_no')}"

--- a/macros/L10n-CompatTable.json
+++ b/macros/L10n-CompatTable.json
@@ -56,6 +56,13 @@
         "ja"   : "有り",
         "ru"   : "Да"
     },
+    "supportsShort_yes_title": {
+        "en-US": "Please update this with the earliest version of support.",
+        "de"   : "Bitte mit der frühsten Version updaten in der Support vorhanden ist.",
+        "fr"   : "Veuillez mettre à jour avec la version minimale du support",
+        "ja"   : "最新の対応状況に更新してください。",
+        "ru"   : "Пожалуйста, замените этот шаблон на указание самой ранней поддерживаемой версии."
+    },
     "supportsShort_no": {
         "en-US": "No",
         "de"   : "Nein",

--- a/macros/L10n-CompatTable.json
+++ b/macros/L10n-CompatTable.json
@@ -49,12 +49,12 @@
         "ru"   : "Замечания реализации"
     },
     "supportsShort_yes": {
-        "en-US": "Yes",
-        "de"   : "Ja",
-        "es"   : "Si",
-        "fr"   : "Oui",
-        "ja"   : "有り",
-        "ru"   : "Да"
+        "en-US": "(Yes)",
+        "de"   : "(Ja)",
+        "es"   : "(Si)",
+        "fr"   : "(Oui)",
+        "ja"   : "(有り)",
+        "ru"   : "(Да)"
     },
     "supportsShort_yes_title": {
         "en-US": "Please update this with the earliest version of support.",


### PR DESCRIPTION
"No" is currently rendered as "(No)". The parenthesis only make sense for "(Yes)" and we never had them for "No". Adding title tooltips to further clarify the meanings as well.