### PR TITLE
bug 1380045: Update link to Editor's Guide

### DIFF
--- a/macros/EditorGuideQuicklinks.ejs
+++ b/macros/EditorGuideQuicklinks.ejs
@@ -24,7 +24,7 @@ switch (env.locale) {
 <section id="Quick_Links">
 <ol>
  <li><a href="#" title="#"><%-s_guide%></a>
- <%-template("ListSubpages", ["/en-US/docs/Project:MDN/Contributing/Editor_guide", 1, 0, 1])%>
+ <%-template("ListSubpages", ["/en-US/docs/MDN/Contribute/Editor", 1, 0, 1])%>
  </li>
  <li><a href="http://docs.ckeditor.com/"><%-s_ckeditor%></a></li>
  <li><a href="http://mxr.mozilla.org/"><%-s_mxr%></a></li>


### PR DESCRIPTION
Project:MDN/Contributing/Editor_guide has [no children](https://developer.mozilla.org/en-US/docs/Project:MDN/Contributing/Editor_guide$children). Changed to new location, which does have [subpages](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Editor$children).