### PR TITLE
bug 1368134: fix page.subpagesExpand

### DIFF
--- a/lib/kumascript/api.js
+++ b/lib/kumascript/api.js
@@ -15,10 +15,11 @@
 // TODO: Maybe split this module up into namespace-specific modules for easier
 // editing?
 
-/*jshint node: true, expr: false, boss: true */
+/*jshint node: true, esversion: 6, expr: false, boss: true*/
 
 // ### Prerequisites
-var util = require('util'),
+var url = require('url'),
+    util = require('util'),
     _ = require('underscore'),
     async = require('async'),
     Fiber = require('fibers'),
@@ -76,7 +77,7 @@ var KumaAPI = ks_utils.Class(BaseAPI, {
 
     // #### url
     // Expose url from node.js to templates
-    url: require('url'),
+    url: url,
 
     // #### htmlEscape(string)
     // Escape the given string for HTML inclusion.
@@ -117,7 +118,6 @@ var KumaAPI = ks_utils.Class(BaseAPI, {
         f.wait();
         return result;
     }
-
 });
 
 // ### APIContext
@@ -370,8 +370,26 @@ var APIContext = ks_utils.Class({
     // #### require(name)
     //
     // Load an npm package (the real "require" has its own cache).
-    require: require
+    require: require,
 
+    /**
+     * Build an absolute URL from the given "path" that uses the
+     * protocol and host of the document service rather than those
+     * of the public-facing website. If the "path" argument is an
+     * absolute URL, everything will be discarded except its "path"
+     * and "hash" attributes (as defined by "url.parse()"). If the
+     * "path" argument is not provided or is falsy, the base URL of
+     * the document service will be returned.
+     */
+    build_api_url: function(path) {
+        if (!path) {
+            return this.options.doc_base_url;
+        }
+        return url.resolve(
+            this.options.doc_base_url,
+            ks_utils.strip_base_url(path)
+        );
+    }
 });
 
 // ### setCaseVariantAliases

--- a/lib/kumascript/macros-worker.js
+++ b/lib/kumascript/macros-worker.js
@@ -83,6 +83,7 @@ self.on('job', function (job) {
             loader: loader,
             autorequire: self.options.autorequire,
             memcache: self.options.memcache,
+            doc_base_url: self.options.doc_base_url,
 
             log: log,
             statsd: statsd,

--- a/lib/kumascript/macros.js
+++ b/lib/kumascript/macros.js
@@ -86,7 +86,8 @@ var MacroProcessor = ks_utils.Class(EventEmitter, {
             options: {
                 autorequire: this.options.autorequire,
                 loader: this.options.loader,
-                memcache: this.options.memcache
+                memcache: this.options.memcache,
+                doc_base_url: this.options.doc_base_url
             }
         });
 

--- a/lib/kumascript/server.js
+++ b/lib/kumascript/server.js
@@ -66,8 +66,12 @@ var Server = ks_utils.Class({
             app = this.app = express();
 
         this.req_cnt = 0;
-
         this.statsd = ks_utils.getStatsD(this.options);
+
+        // Build the root URL of the document API service.
+        this.doc_base_url = ks_utils.get_base_url(
+            this.options.document_url_template
+        );
 
         if (this.options.memcache) {
             var mo = this.options.memcache;
@@ -99,6 +103,10 @@ var Server = ks_utils.Class({
                 }
             });
             this.macro_processor = new ks_macros.MacroProcessor(mp_options);
+        }
+
+        if (!this.macro_processor.options.doc_base_url) {
+            this.macro_processor.options.doc_base_url = this.doc_base_url;
         }
 
         $this.macro_processor.startup(function () {
@@ -256,8 +264,7 @@ var Server = ks_utils.Class({
      */
     readiness_GET: function (req, res) {
         var msg = 'service unavailable ',
-            parts = url.parse(this.options.document_url_template),
-            kumaReadiness = `${parts.protocol}//${parts.host}/readiness`;
+            kumaReadiness = url.resolve(this.doc_base_url, 'readiness');
 
         // First, check that we can load some macros.
         try {

--- a/lib/kumascript/utils.js
+++ b/lib/kumascript/utils.js
@@ -2,10 +2,11 @@
 //
 // This module is the junk drawer. Random useful things go here.
 
-/*jshint node: true, expr: false, boss: true */
+/*jshint node: true, esversion: 6, expr: false, boss: true*/
 
 // ### Prerequisites
 var os = require('os'),
+    url = require('url'),
     crypto = require('crypto'),
     _ = require('underscore');
 
@@ -105,6 +106,28 @@ function md5 (str) {
     return hash.digest('hex');
 }
 
+/**
+ * Returns the base URL of the given argument.
+ */
+function get_base_url(value) {
+    // Build the base URL of the document API service.
+    const parts = url.parse(value);
+    parts.hash = undefined;
+    parts.search = undefined;
+    parts.pathname = undefined;
+    return url.format(parts);
+}
+
+/**
+ * Strips the given argument of its "protocol", "auth", and "host"
+ * components, leaving only its "path" and "hash".
+ */
+function strip_base_url(value) {
+    // Build the base URL of the document API service.
+    const parts = url.parse(value);
+    return parts.path + (parts.hash ? parts.hash : '');
+}
+
 // ### Underscore.js extensions
 _.mixin({
 
@@ -132,5 +155,7 @@ module.exports = {
     tmpl: tmpl,
     FakeMemcached: FakeMemcached,
     md5: md5,
-    getStatsD: getStatsD
+    getStatsD: getStatsD,
+    get_base_url: get_base_url,
+    strip_base_url: strip_base_url
 };

--- a/macros/DekiScript-Page.ejs
+++ b/macros/DekiScript-Page.ejs
@@ -49,18 +49,12 @@
     // Optional depth. Number of levels of children to include, 0 is the path page
     // Optional self, defaults to false. Include the path page in the results
     subpages: function (path, depth, self) {
-        var url = '';
-        if (path) {
-            var p = kuma.url.parse(env.url, true);
-            url = p.protocol + '//' + p.host + encodeURI(path) + '$children';
-        } else {
-            url = env.url + '$children';
-        }
+        var mdn = require_macro('MDN:Common');
+        var url = build_api_url((path ? path : env.url) + '$children');
         var depth_check = parseInt(depth);
-        if(depth_check  >= 0) {
+        if (depth_check >= 0) {
             url += '?depth=' + depth_check;
         }
-        var mdn = require_macro('MDN:Common');
         var subpages = mdn.fetchJSONResource(url);
         var result = [];
         if (subpages != null) {
@@ -78,21 +72,12 @@
     // Optional depth. Number of levels of children to include, 0 is the path page
     // Optional self, defaults to false. Include the path page in the results
     subpagesExpand: function (path, depth, self) {
-        var url = '';
-        if (path) {
-            var p = kuma.url.parse(env.url, true);
-            url = p.protocol + '//' + p.host + encodeURI(path) + '$children';
-        } else {
-            url = env.url + '$children';
-        }
-
-        url += '?expand';
-
+        var mdn = require_macro('MDN:Common');
+        var url = build_api_url((path ? path : env.url) + '$children?expand');
         var depth_check = parseInt(depth);
-        if(depth_check  >= 0) {
+        if (depth_check >= 0) {
             url += '&depth=' + depth_check;
         }
-        var mdn = require_macro('MDN:Common');
         var subpages = mdn.fetchJSONResource(url);
         var result = [];
         if (subpages != null) {
@@ -227,14 +212,8 @@
     },
 
     translations: function (path) {
-        var url = '';
-        if (path) {
-            var p = kuma.url.parse(env.url, true);
-            url = p.protocol + '//' + p.host + encodeURI(path) + '$json';
-        } else {
-            url = env.url + '$json';
-        }
         var mdn = require_macro('MDN:Common');
+        var url = build_api_url((path ? path : env.url) + '$json');
         var json = mdn.fetchJSONResource(url);
         var result = [];
         if (json != null) {

--- a/macros/DekiScript-Wiki.ejs
+++ b/macros/DekiScript-Wiki.ejs
@@ -1,4 +1,4 @@
-<% var wiki = module.exports = buildAPI({
+<%  var wiki = module.exports = buildAPI({
     /*
     * Given a MediaWiki path attempt to update it to a Kuma path
     * This is not a DekiScript function
@@ -33,27 +33,28 @@
         return b.replace(/(<([^>]+)>)/ig, "");
     },
 
-    // Given a path, attempt to construct an absolute URL to the wiki.
-    // This is not a DekiScript function, but it's used by many of those below.
-    buildAbsoluteURL: function (path) {
-        var p = kuma.url.parse(env.url, true);
-        var base_url = p.protocol + '//' + p.host;
-
+    /**
+     * Prepares the provided path by looking for legacy paths that need to be
+     * prefixed by "/en-US/docs", as well as ensuring it starts with a "/" and
+     * replacing its spaces (whether encoded or not) with underscores.
+     */
+    preparePath: function (path) {
+        if (path.charAt(0) != '/') {
+            path = '/' + path;
+        }
         if (path.indexOf('/docs') == -1) {
             // HACK: If this looks like a legacy wiki URL, throw /en-US/docs
             // in front of it. That will trigger the proper redirection logic
             // until/unless URLs are corrected in templates
-            base_url += '/en-US/docs';
+            path = '/en-US/docs' + path;
         }
-        var re1 = / /gi;
-        var re2 = /%20/gi;
+        return path.replace(/ |%20/gi, "_");
+    },
 
-        path = path.replace(re1, "_");
-        path = path.replace(re2, "_");
-
-        if (path.charAt(0) != '/') { base_url += '/'; }
-
-        return base_url + path;
+    // Given a path, attempt to construct an absolute URL to the wiki.
+    // This is not a DekiScript function, but it's used by many of those below.
+    buildAbsoluteURL: function (path) {
+        return build_api_url(wiki.preparePath(path));
     },
 
     // Check if the given wiki page exists.
@@ -247,10 +248,11 @@
     // Retrieve the full uri of a given wiki page.
     // [See also](http://developer.mindtouch.com/en/docs/DekiScript/Reference/Wiki_Functions_and_Variables/Wiki.Uri)
     uri: function (path, query) {
-        var out = wiki.buildAbsoluteURL(path);
-
-        if (query) { out += '?' + query; }
-
+        const parts = kuma.url.parse(env.url);
+        var out = parts.protocol + '//' + parts.host + wiki.preparePath(path);
+        if (query) {
+            out += '?' + query;
+        }
         return out;
     },
 

--- a/tests/macros/test-dekiscript-page.js
+++ b/tests/macros/test-dekiscript-page.js
@@ -93,6 +93,7 @@ describeMacro('dekiscript-page', function () {
                   fetch_url0 = fetch_url + '?depth=0',
                   fetch_url1 = fetch_url + '?depth=1',
                   fetch_url2 = fetch_url + '?depth=2';
+            macro.ctx.options.doc_base_url = base_url;
             macro.ctx.require_macro = require_macro_stub;
             require_macro_stub.withArgs('MDN:Common').returns({
                 fetchJSONResource: fetch_stub
@@ -177,6 +178,7 @@ describeMacro('dekiscript-page', function () {
                   fetch_url0 = fetch_url + '&depth=0',
                   fetch_url1 = fetch_url + '&depth=1',
                   fetch_url2 = fetch_url + '&depth=2';
+            macro.ctx.options.doc_base_url = base_url;
             macro.ctx.require_macro = require_macro_stub;
             require_macro_stub.withArgs('MDN:Common').returns({
                 fetchJSONResource: fetch_stub
@@ -271,6 +273,7 @@ describeMacro('dekiscript-page', function () {
                   require_macro_stub = sinon.stub(),
                   fetch_url = base_url + fix_url + '$json',
                   fetch_junk_url = base_url + '/en-US/docs/junk$json';
+            macro.ctx.options.doc_base_url = base_url;
             macro.ctx.require_macro = require_macro_stub;
             require_macro_stub.withArgs('MDN:Common').returns({
                 fetchJSONResource: fetch_stub

--- a/tests/macros/test-dekiscript-wiki.js
+++ b/tests/macros/test-dekiscript-wiki.js
@@ -30,6 +30,7 @@ describeMacro('dekiscript-wiki', function () {
     });
     describe('test "buildAbsoluteURL"', function () {
         beforeEachMacro(function (macro) {
+            macro.ctx.options.doc_base_url = 'https://developer.mozilla.org';
             return macro.require().then(function (pkg) {
                 macro.buildAbsoluteURL = pkg.buildAbsoluteURL;
             });

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -2,6 +2,7 @@
 
 var assert = require('chai').assert,
     kumascript = require('..'),
+    ks_api = kumascript.api,
     ks_server = kumascript.server,
     ks_macros = kumascript.macros,
     ks_test_utils = kumascript.test_utils,
@@ -109,5 +110,36 @@ describe('test-api', function () {
                 assert.equal(result.trim(), expected.trim());
             }
         );
+    });
+
+    describe('The API offers a function to build absolute API URLs', function () {
+        const test_path = 'en-US/docs/<Web>?look=fancy&font=big#note';
+        beforeEach(function() {
+            this.doc_base_url = 'https://api:8000';
+            this.api = new ks_api.APIContext({
+                doc_base_url: this.doc_base_url
+            });
+        });
+        it('test with falsy paths', function () {
+            assert.equal(this.api.build_api_url(), this.doc_base_url);
+            assert.equal(this.api.build_api_url(''), this.doc_base_url);
+            assert.equal(this.api.build_api_url(null), this.doc_base_url);
+            assert.equal(this.api.build_api_url(undefined), this.doc_base_url);
+        });
+        it('test with "/"', function () {
+            assert.equal(this.api.build_api_url('/'), this.doc_base_url + '/');
+        });
+        [
+            test_path,
+            '/' + test_path,
+            'http://localhost:8000/' + test_path
+        ].forEach(function (path) {
+            it(`test with "${path}"`, function () {
+                assert.equal(
+                    this.api.build_api_url(path),
+                    this.doc_base_url + '/' +  encodeURI(test_path)
+                );
+            });
+        });
     });
 });


### PR DESCRIPTION
This PR depends on #240 to provide regression tests for the macro functions it refactors.

This PR fixes the problem unique to the Docker environment where macro functions like `subpagesExpand()` fail when making document-related requests because they use the host within the request URL (`env.url`) (e.g., `localhost:8000`) rather than the hostname of the proper container.
- extracts base URL for the "API" service (Kuma service dedicated to handling document requests from KumaScript) from the `document_url_template` setting.
- adds a `build_api_url()` function to each macro's context (globals) that builds an absolute URL to the "API" service.
- modifies the `subpages`, `subpagesExpand`, and `translations` functions within `DekiScript-Page.ejs` to construct URL's via `build_api_url()` rather than `env.url`.
- modifies the `buildAbsoluteURL` function within `DekiScript-Wiki.ejs`to construct URL's via `build_api_url()` rather than `env.url`.
- refactors the `uri` function within `DekiScript-Wiki.ejs` such that it continues to construct URL's using the request URL (`env.url`) since it's used to create links on pages.
- adds tests for the new `build_api_url()` function