### PR TITLE
Updating the Preload specname

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -751,7 +751,7 @@ var specList = {
     },
     'Preload':{
         name : 'Preload',
-        url  : 'http://www.w3.org/TR/preload/'
+        url  : 'https://w3c.github.io/preload/'
     },
     'Presentation':{
         name : 'Presentation API',


### PR DESCRIPTION
Updating the Preload specname to point to the latest Preload ED, not the WD