### PR TITLE
Adding alternative distribution/installation articles

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -100,8 +100,8 @@ function currentPageIsUnder(root) {
 
     <li><a href="<%=baseURL%>Themes"><strong>Themes</strong></a></li>
 
-    <li><a href="<%=baseURL%>Distribution"><strong>Publishing add-ons</strong></a></li>
-    <li><a href="<%=baseURL%>Distribution">Guides</a>
+    <li><a href="<%=baseURL%>Distribution"><strong>Publishing and Distribution</strong></a></li>
+    <li><a href="<%=baseURL%>Distribution">Publishing add-ons</a>
       <ol>
         <li><a href="<%=baseURL%>Distribution">Signing and distribution overview</a></li>
         <li><a href="<%=baseURL%>Distribution/Submitting_an_add-on">Submit an add-on</a></li>
@@ -110,6 +110,13 @@ function currentPageIsUnder(root) {
         <li><a href="<%=baseURL%>AMO/Policy/Agreement">Developer agreement</a></li>
         <li><a href="<%=baseURL%>AMO/Policy/Featured">Featured add-ons</a></li>
         <li><a href="<%=baseURL%>AMO/Policy/Contact">Contact addons.mozilla.org</a></li>
+      </ol>
+    </li>
+    <li><a href="<%=baseURL%>Alternative_distribution_options">Distributing add-ons</a>
+      <ol>
+        <li><a href="<%=baseURL%>Alternative_distribution_options/Sideloading_add-ons">For sideloading</a></li>
+        <li><a href="<%=baseURL%>Alternative_distribution_options/Add-ons_for_desktop_apps">For desktop apps</a></li>
+        <li><a href="<%=baseURL%>Alternative_distribution_options/Add-ons_in_the_enterprise">For an enterprise</a></li>
       </ol>
     </li>
 


### PR DESCRIPTION
* Renaming the Publishing menu > Publishing and Distribution
* Changing the Guide submenu to Publishing add-ons
* Added second, new Distributing add-ons submenu with three articles: for sideloading, for desktop apps and for the enterprise.