### PR TITLE
Fix issue #269: Functions need access to "syntax"

### DIFF
--- a/macros/csssyntax.ejs
+++ b/macros/csssyntax.ejs
@@ -444,7 +444,7 @@ if (name === "preview-wiki-content") {
     } else if (data.properties[name]) {
         rawSyntax = data.properties[name].syntax;
     } else if (data.syntaxes[addBrackets(name)]) {
-        rawSyntax = data.syntaxes[addBrackets(name)];
+        rawSyntax = data.syntaxes[addBrackets(name)].syntax;
     }
 
     formattedSyntax = formatSyntax(rawSyntax);


### PR DESCRIPTION
This was missed in this PR:
https://github.com/mozilla/kumascript/pull/208

The data structure had been changed here:
https://github.com/mdn/data/pull/66

Only "function pages" like attr(), calc() etc, where the syntax is defined in this file https://github.com/mdn/data/blob/master/css/syntaxes.json should be affected and throw KS errors. This fixes that.